### PR TITLE
Move common functions to an include file

### DIFF
--- a/base.inc
+++ b/base.inc
@@ -1,0 +1,87 @@
+<?php
+// Common functions used by many/all pages
+
+// Output valid HTML page header
+function output_header($header="", $addl_links=[], $js="")
+{
+    if($header)
+    {
+        $title = "PP Workbench: $header";
+    }
+    else
+    {
+        $title = "Post-Processing Workbench";
+        $header = "pp workbench";
+    }
+
+    echo <<<HEAD
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name=viewport content="width=device-width, initial-scale=1">
+    <title>$title</title>
+    <link rel="stylesheet" type="text/css" href="rfrank.css">
+    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
+    <script>$js</script>
+  </head>
+  <body>
+  <div id="header" class='hsty'>$header</div>
+	<hr style='border:none; border-bottom:1px solid silver;'>  
+HEAD;
+
+    // Register a shutdown callback to always close out the page
+    register_shutdown_function('output_footer', $addl_links);
+}
+
+// You should not call this function directly as it is registered as a
+// shutdown callback with output_header() to ensure that the HTML is
+// always closed properly.
+function output_footer($addl_links=[])
+{
+    // prepend a return to the main page
+    if(basename($_SERVER["PHP_SELF"]) != "index.php")
+    {
+        $addl_links = array_merge(["index.php" => "MAIN PAGE"], $addl_links);
+    }
+
+    $links = [];
+    foreach($addl_links as $url => $name)
+    {
+        $links[] = "<a style='font-size: 70%' href='$url'>$name</a>";
+    }
+    $links = join("&nbsp;|&nbsp;", $links);
+
+    echo <<<FOOT
+  <div id="footer">
+    <hr style='border:none; border-bottom:1px solid silver;'>
+    <table style='width: 100%'>
+      <tr>
+        <td style='text-align: left'>$links</td>
+        <td style='text-align: right'>
+        <a style='font-size: 70%' href='mailto:rfrank@rfrank.net'>CONTACT</a></td>
+      </tr>
+    </table>
+  </div>
+  </body>
+</html>
+FOOT;
+}
+
+// get user's IP address
+function getUserIP()
+{
+    if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER) && !empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        if (strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',') > 0) {
+            $addr = explode(",", $_SERVER['HTTP_X_FORWARDED_FOR']);
+            return trim($addr[0]);
+        }
+        else {
+            return $_SERVER['HTTP_X_FORWARDED_FOR'];
+        }
+    }
+    else {
+        return $_SERVER['REMOTE_ADDR'];
+    }
+}
+

--- a/index.php
+++ b/index.php
@@ -1,8 +1,8 @@
 <?php
+require_once("base.inc");
 
 output_header();
 output_content();
-output_footer();
 
 function output_content()
 {
@@ -41,37 +41,3 @@ files. Follow these links for details and to access the programs:</p>
 MENU;
 }
 
-function output_header()
-{
-    echo <<<HEAD
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name=viewport content="width=device-width, initial-scale=1">
-    <title>Post-Processing Workbench</title>
-    <link rel="stylesheet" type="text/css" href="rfrank.css">
-  </head>
-  <body>
-  <div id="header" class='hsty'>pp workbench</div>
-	<hr style='border:none; border-bottom:1px solid silver;'>  
-HEAD;
-}
-
-function output_footer()
-{
-  echo <<<FOOT
-  <div id="footer">
-    <hr style='border:none; border-bottom:1px solid silver;'>
-    <table summary="" width="100%">
-      <tr>
-        <td align="left">&nbsp;</td>
-        <td align="right">
-        <a style='font-size:70%' href='mailto:rfrank@rfrank.net'>CONTACT</a></td>
-      </tr>
-    </table>
-  </div>
-  </body>
-</html>
-FOOT;
-}

--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -1,23 +1,5 @@
 <?php
-
-// get user's IP address
-
-function getUserIP()
-{
-    if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER) && !empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-        if (strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',') > 0) {
-            $addr = explode(",", $_SERVER['HTTP_X_FORWARDED_FOR']);
-            return trim($addr[0]);
-        }
-        else {
-            return $_SERVER['HTTP_X_FORWARDED_FOR'];
-        }
-    }
-    else {
-        return $_SERVER['REMOTE_ADDR'];
-    }
-}
-
+require_once("base.inc");
 
 $errors = array(); // place to save error messages
 $work = "t"; // a working folder for project data
@@ -249,13 +231,7 @@ $output = shell_exec($command);
 
 // ----- display results -------------------------------------------
 
-echo "<!doctype html>";
-echo "<html lang='en'>";
-echo "<head>";
-echo "  <link rel='stylesheet' type='text/css' href='rfrank.css'>";
-echo "</head>";
-echo "<body>";
-echo "<p><b>Ppcomp Results</b></p>";
+output_header("ppcomp Results");
 
 $reportok = false;
 
@@ -273,7 +249,3 @@ if ($reportok) {
     </p>For more assistance, please email rfrank@rfrank.net and include this project name: ${upid}</p>";
 }
 
-echo "</body>";
-echo "</html>";
-
-?>

--- a/ppcomp.php
+++ b/ppcomp.php
@@ -1,8 +1,8 @@
 <?php
+require_once("base.inc");
 
-output_header();
+output_header("ppcomp", ["techinfo-ppcomp.php" => "TECH INFO"]);
 output_content();
-output_footer();
 
 function output_content()
 {
@@ -107,41 +107,3 @@ It is used as part of the PP Workbench with permission.
 MENU;
 }
 
-function output_header()
-{
-    echo <<<HEAD
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name=viewport content="width=device-width, initial-scale=1">
-    <title>PP Workbench: ppcomp</title>
-    <link rel="stylesheet" type="text/css" href="rfrank.css">
-  </head>
-  <body>
-  <div id="header" class='hsty'>ppcomp</div>
-	<hr style='border:none; border-bottom:1px solid silver;'>  
-HEAD;
-}
-
-function output_footer()
-{
-  echo <<<FOOT
-  <div id="footer">
-    <hr style='border:none; border-bottom:1px solid silver;'>
-    <table summary="" width="100%">
-      <tr>
-        <td align="left">
-        	<a style='font-size:70%' href='index.php'>MAIN PAGE</a>
-        	&nbsp;|&nbsp;
-        	<a style='font-size:70%' href='techinfo-ppcomp.php'>TECH INFO</a>
-        </td>
-        <td align="right">
-        <a style='font-size:70%' href='mailto:rfrank@rfrank.net'>CONTACT</a></td>
-      </tr>
-    </table>
-  </div>
-  </body>
-</html>
-FOOT;
-}

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -1,23 +1,5 @@
 <?php
-
-// get user's IP address
-
-function getUserIP()
-{
-    if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER) && !empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-        if (strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',') > 0) {
-            $addr = explode(",", $_SERVER['HTTP_X_FORWARDED_FOR']);
-            return trim($addr[0]);
-        }
-        else {
-            return $_SERVER['HTTP_X_FORWARDED_FOR'];
-        }
-    }
-    else {
-        return $_SERVER['REMOTE_ADDR'];
-    }
-}
-
+require_once("base.inc");
 
 $errors = array(); // place to save error messages
 $work = "t"; // a working folder for project data
@@ -165,13 +147,7 @@ $output = shell_exec($command);
 
 // ----- display results -------------------------------------------
 
-echo "<!doctype html>";
-echo "<html lang='en'>";
-echo "<head>";
-echo "  <link rel='stylesheet' type='text/css' href='rfrank.css'>";
-echo "</head>";
-echo "<body>";
-echo "<p><b>Pphtml Results</b></p>";
+output_header("pphtml Results");
 
 $reportok = false;
 
@@ -189,7 +165,3 @@ if ($reportok) {
     </p>For more assistance, please email rfrank@rfrank.net and include this project name: ${upid}</p>";
 }
 
-echo "</body>";
-echo "</html>";
-
-?>

--- a/pphtml.php
+++ b/pphtml.php
@@ -1,8 +1,8 @@
 <?php
+require_once("base.inc");
 
-output_header();
+output_header("pphtml", ["techinfo-pphtml.php" => "TECH INFO"]);
 output_content();
-output_footer();
 
 function output_content()
 {
@@ -32,41 +32,3 @@ of the run. Left click to view or right click the link to download the results.<
 MENU;
 }
 
-function output_header()
-{
-    echo <<<HEAD
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name=viewport content="width=device-width, initial-scale=1">
-    <title>PP Workbench: pphtml</title>
-    <link rel="stylesheet" type="text/css" href="rfrank.css">
-  </head>
-  <body>
-  <div id="header" class='hsty'>pphtml</div>
-	<hr style='border:none; border-bottom:1px solid silver;'>  
-HEAD;
-}
-
-function output_footer()
-{
-  echo <<<FOOT
-  <div id="footer">
-    <hr style='border:none; border-bottom:1px solid silver;'>
-    <table summary="" width="100%">
-      <tr>
-        <td align="left">
-        	<a style='font-size:70%' href='index.php'>MAIN PAGE</a>
-        	&nbsp;|&nbsp;
-        	<a style='font-size:70%' href='techinfo-pphtml.php'>TECH INFO</a>
-        </td>
-        <td align="right">
-        <a style='font-size:70%' href='mailto:rfrank@rfrank.net'>CONTACT</a></td>
-      </tr>
-    </table>
-  </div>
-  </body>
-</html>
-FOOT;
-}

--- a/ppsmq-action.php
+++ b/ppsmq-action.php
@@ -1,23 +1,5 @@
 <?php
-
-// get user's IP address
-
-function getUserIP()
-{
-    if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER) && !empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-        if (strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',') > 0) {
-            $addr = explode(",", $_SERVER['HTTP_X_FORWARDED_FOR']);
-            return trim($addr[0]);
-        }
-        else {
-            return $_SERVER['HTTP_X_FORWARDED_FOR'];
-        }
-    }
-    else {
-        return $_SERVER['REMOTE_ADDR'];
-    }
-}
-
+require_once("base.inc");
 
 $errors = array(); // place to save error messages
 $work = "t"; // a working folder for project data
@@ -131,13 +113,7 @@ $output = shell_exec($command);
 
 // ----- display results -------------------------------------------
 
-echo "<!doctype html>";
-echo "<html lang='en'>";
-echo "<head>";
-echo "  <link rel='stylesheet' type='text/css' href='rfrank.css'>";
-echo "</head>";
-echo "<body>";
-echo "<p><b>Ppsmq Results</b></p>";
+output_header("ppsmq Results");
 
 $reportok = false;
 
@@ -155,7 +131,3 @@ if ($reportok) {
     </p>For more assistance, please email rfrank@rfrank.net and include this project name: ${upid}</p>";
 }
 
-echo "</body>";
-echo "</html>";
-
-?>

--- a/ppsmq.php
+++ b/ppsmq.php
@@ -1,8 +1,8 @@
 <?php
+require_once("base.inc");
 
-output_header();
+output_header("ppsmq", ["techinfo-ppsmq.php" => "TECH INFO"]);
 output_content();
-output_footer();
 
 function output_content()
 {
@@ -45,41 +45,3 @@ echo <<<MENU
 MENU;
 }
 
-function output_header()
-{
-    echo <<<HEAD
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name=viewport content="width=device-width, initial-scale=1">
-    <title>PP Workbench: ppsmq</title>
-    <link rel="stylesheet" type="text/css" href="rfrank.css">
-  </head>
-  <body>
-  <div id="header" class='hsty'>ppsmq</div>
-	<hr style='border:none; border-bottom:1px solid silver;'>  
-HEAD;
-}
-
-function output_footer()
-{
-  echo <<<FOOT
-  <div id="footer">
-    <hr style='border:none; border-bottom:1px solid silver;'>
-    <table summary="" width="100%">
-      <tr>
-        <td align="left">
-        	<a style='font-size:70%' href='index.php'>MAIN PAGE</a>
-        	&nbsp;|&nbsp;
-        	<a style='font-size:70%' href='techinfo-ppsmq.php'>TECH INFO</a>
-        </td>
-        <td align="right">
-        <a style='font-size:70%' href='mailto:rfrank@rfrank.net'>CONTACT</a></td>
-      </tr>
-    </table>
-  </div>
-  </body>
-</html>
-FOOT;
-}

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -1,23 +1,5 @@
 <?php
-
-// get user's IP address
-
-function getUserIP()
-{
-    if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER) && !empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-        if (strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',') > 0) {
-            $addr = explode(",", $_SERVER['HTTP_X_FORWARDED_FOR']);
-            return trim($addr[0]);
-        }
-        else {
-            return $_SERVER['HTTP_X_FORWARDED_FOR'];
-        }
-    }
-    else {
-        return $_SERVER['REMOTE_ADDR'];
-    }
-}
-
+require_once("base.inc");
 
 $errors = array(); // place to save error messages
 $work = "t"; // a working folder for project data
@@ -291,13 +273,7 @@ $output = shell_exec($command);
 
 // ----- display results -------------------------------------------
 
-echo "<!doctype html>";
-echo "<html lang='en'>";
-echo "<head>";
-echo "  <link rel='stylesheet' type='text/css' href='rfrank.css'>";
-echo "</head>";
-echo "<body>";
-echo "<p><b>Pptext Results</b></p>";
+output_header("pptext Results");
 
 $reportok = false;
 
@@ -319,7 +295,3 @@ if ($reportok) {
     </p>For more assistance, please email rfrank@rfrank.net and include this project name: ${upid}</p>";
 }
 
-echo "</body>";
-echo "</html>";
-
-?>

--- a/pptext.php
+++ b/pptext.php
@@ -1,8 +1,8 @@
 <?php
+require_once("base.inc");
 
-output_header();
+output_header("pptext", ["techinfo-pptext.php" => "TECH INFO"], get_js());
 output_content();
-output_footer();
 
 function output_content()
 {
@@ -110,18 +110,9 @@ $output = shell_exec($command);
 echo "<div style='text-align:right; font-size:70%; color:white;'>pptext version: ".$output."</div>";
 }
 
-function output_header()
+function get_js()
 {
-    echo <<<HEAD
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name=viewport content="width=device-width, initial-scale=1">
-    <title>PP Workbench: pptext</title>
-    <link rel="stylesheet" type="text/css" href="rfrank.css">
-    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
-    <script>
+    return <<<JS
     $(document).ready(function() {
         $('.chk_boxes').click(function(){
             $('.chk_boxes1').prop('checked',this.checked);
@@ -138,33 +129,6 @@ function output_header()
         $('.chk_boxes1').prop('checked',true);
         $('.chk_boxes').prop('checked',true);       
     });
-    </script>
-  </head>
-  <body>
-  <div id="header" class='hsty'>pptext</div>
-    <hr style='border:none; border-bottom:1px solid silver;'>  
-HEAD;
+JS;
 }
 
-function output_footer()
-{
-  echo <<<FOOT
-  <div id="footer">
-    <hr style='border:none; border-bottom:1px solid silver;'>
-    <table summary="" width="100%">
-      <tr>
-        <td align="left">
-            <a style='font-size:70%' href='index.php'>MAIN PAGE</a>
-            &nbsp;|&nbsp;
-            <a style='font-size:70%' href='techinfo-pptext.php'>TECH INFO</a>
-        </td>
-        <td align="right">
-        <a style='font-size:70%' href='mailto:rfrank@rfrank.net'>CONTACT</a></td>
-      </tr>
-    </table>
-  </div>
-
-  </body>
-</html>
-FOOT;
-}

--- a/techinfo-ppcomp.php
+++ b/techinfo-ppcomp.php
@@ -1,8 +1,9 @@
 <?php
+require_once("base.inc");
 
-output_header();
+output_header("ppcomp", ["ppcomp.php" => "PPCOMP"]);
+?>
 
-echo <<<BODY
 <p>Technical info for ppcomp.</p>
 <ol>
 <li>
@@ -12,43 +13,4 @@ Users who want a compare tool with many more options might find
 the <a href='https://pptools.tangledhelix.com'>tangledhelix</a> site useful.
 </li>
 </ol>
-BODY;
 
-output_footer();
-
-function output_header()
-{
-    echo <<<HEAD
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name=viewport content="width=device-width, initial-scale=1">
-    <title>PP Workbench</title>
-    <link rel="stylesheet" type="text/css" href="rfrank.css">
-  </head>
-
-<body>
-  <div id="header" class='hsty'>ppcomp</div>
-  <hr style='border:none; border-bottom:1px solid silver;'>
-HEAD;
-}
-
-function output_footer()
-{
-    echo <<<FOOT
-  <div id="footer">
-    <hr style='border:none; border-bottom:1px solid silver;'>
-    <table summary="" width="100%">
-      <tr>
-        <td align="left">
-        <a style='font-size:70%' href='ppcomp.php'>PPCOMP</a></td>
-        <td align="right">
-        <a style='font-size:70%' href='mailto:rfrank@rfrank.net'>CONTACT</a></td>
-      </tr>
-    </table>
-  </div>
-  </body>
-</html>
-FOOT;
-}

--- a/techinfo-pphtml.php
+++ b/techinfo-pphtml.php
@@ -1,8 +1,9 @@
 <?php
+require_once("base.inc");
 
-output_header();
+output_header("pphtml", ["pphtml.php" => "PPHTML"]);
+?>
 
-echo <<<BODY
 <p>Technical info for pphtml.</p>
 <ol>
 <li>There is a valid CSS construction of <tt style='border: 1px solid silver; background-color:#FFFFCC'>.class1.class2</tt> that pptext does
@@ -11,43 +12,4 @@ not handle correctly. That definition means "an element with both class1 and cla
 Currently, that construction will show up as "defined but not used".
 </li>
 </ol>
-BODY;
 
-output_footer();
-
-function output_header()
-{
-    echo <<<HEAD
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name=viewport content="width=device-width, initial-scale=1">
-    <title>PP Workbench</title>
-    <link rel="stylesheet" type="text/css" href="rfrank.css">
-  </head>
-
-<body>
-  <div id="header" class='hsty'>pphtml</div>
-  <hr style='border:none; border-bottom:1px solid silver;'>
-HEAD;
-}
-
-function output_footer()
-{
-    echo <<<FOOT
-  <div id="footer">
-    <hr style='border:none; border-bottom:1px solid silver;'>
-    <table summary="" width="100%">
-      <tr>
-        <td align="left">
-        <a style='font-size:70%' href='pphtml.php'>PPHTML</a></td>
-        <td align="right">
-        <a style='font-size:70%' href='mailto:rfrank@rfrank.net'>CONTACT</a></td>
-      </tr>
-    </table>
-  </div>
-  </body>
-</html>
-FOOT;
-}

--- a/techinfo-ppsmq.php
+++ b/techinfo-ppsmq.php
@@ -1,50 +1,12 @@
 <?php
+require_once("base.inc");
 
-output_header();
+output_header("ppsmq", ["ppsmq.php" => "PPSMQ"]);
+?>
 
-echo <<<BODY
 <p>Technical info for ppsmq.</p>
 <ol>
 <li> to be added.
 </li>
 </ol>
-BODY;
 
-output_footer();
-
-function output_header()
-{
-    echo <<<HEAD
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name=viewport content="width=device-width, initial-scale=1">
-    <title>PP Workbench</title>
-    <link rel="stylesheet" type="text/css" href="rfrank.css">
-  </head>
-
-<body>
-  <div id="header" class='hsty'>ppsmq</div>
-  <hr style='border:none; border-bottom:1px solid silver;'>
-HEAD;
-}
-
-function output_footer()
-{
-    echo <<<FOOT
-  <div id="footer">
-    <hr style='border:none; border-bottom:1px solid silver;'>
-    <table summary="" width="100%">
-      <tr>
-        <td align="left">
-        <a style='font-size:70%' href='ppsmq.php'>PPSMQ</a></td>
-        <td align="right">
-        <a style='font-size:70%' href='mailto:rfrank@rfrank.net'>CONTACT</a></td>
-      </tr>
-    </table>
-  </div>
-  </body>
-</html>
-FOOT;
-}

--- a/techinfo-pptext.php
+++ b/techinfo-pptext.php
@@ -1,8 +1,9 @@
 <?php
+require_once("base.inc");
 
-output_header();
+output_header("pptext", ["pptext.php" => "PPTEXT"]);
+?>
 
-echo <<<BODY
 <p><b>Technical Notes for pptext</b></p>
 
 <ul class='circle'>
@@ -189,43 +190,3 @@ and always show all reports, the verbose switch is provided.</p>
 <p>writeup</p>
 -->
 
-BODY;
-
-output_footer();
-
-function output_header()
-{
-    echo <<<HEAD
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name=viewport content="width=device-width, initial-scale=1">
-    <title>PP Workbench</title>
-    <link rel="stylesheet" type="text/css" href="rfrank.css">
-  </head>
-
-<body>
-  <div id="header" class='hsty'>pptext</div>
-  <hr style='border:none; border-bottom:1px solid silver;'>
-HEAD;
-}
-
-function output_footer()
-{
-    echo <<<FOOT
-  <div id="footer">
-    <hr style='border:none; border-bottom:1px solid silver;'>
-    <table summary="" width="100%">
-      <tr>
-        <td align="left">
-        <a style='font-size:70%' href='pptext.php'>PPTEXT</a></td>
-        <td align="right">
-        <a style='font-size:70%' href='mailto:rfrank@rfrank.net'>CONTACT</a></td>
-      </tr>
-    </table>
-  </div>
-  </body>
-</html>
-FOOT;
-}


### PR DESCRIPTION
Move three common functions to a single file rather than redefining them in each file.

We use a shutdown function in `output_header()` to automatically call `output_footer()` when the PHP script ends. This ensures that the HTML page is always properly closed and avoids the need to call the footer function at the end of every page.

There are only two minor functional changes with this MR:
* techinfo pages now include a link back to the main page
* result pages now include a footer

You can view this code live at [common-functions](https://www.pgdp.org/~cpeel/ppwb.branch/common-functions/index.php).