### PR TITLE
Move workdir init, logging, and upload process to base.inc

### DIFF
--- a/base.inc
+++ b/base.inc
@@ -76,6 +76,18 @@ function output_footer($addl_links=[])
 FOOT;
 }
 
+// initialize a working directory to store uploaded and processed files
+function init_workdir()
+{
+    $work = "t";
+    $upid = uniqid('r');
+
+    $workdir = "$work/$upid";
+    mkdir($workdir, 0755);
+
+    return [$workdir, $upid];
+}
+
 // get user's IP address
 function getUserIP()
 {

--- a/base.inc
+++ b/base.inc
@@ -85,3 +85,34 @@ function getUserIP()
     }
 }
 
+// log tool access
+function log_tool_access($tool, $upid, $work="t")
+{
+    // make a record of this attempted run ---
+    // format is:
+    //    2019-03-31 12:46:44 pptext r5ca0b6b499bec \
+    //    67.161.200.103 [Littleton, United States]
+
+    $ip = getUserIP();
+    $access_key = 'f00ad0e10a4ebe4ec5cb3ffd6c1dc4c8';
+
+    // Initialize CURL:
+    $ch = curl_init("http://api.ipstack.com/$ip?access_key=$access_key");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+    // Store the data:
+    $json = curl_exec($ch);
+    curl_close($ch);
+
+    // Decode JSON response:
+    $api_result = json_decode($json, true);
+
+    // from: https://ipstack.com/documentation
+    $city = $api_result['city'];
+    $country = $api_result['country_name'];
+
+    $s = sprintf("%s %6s %s %s [%s, %s]\n",
+        date('Y-m-d H:i:s'), $tool, $upid, $ip, $city, $country
+    );
+    file_put_contents($work . "/access.log", $s, FILE_APPEND);
+}

--- a/base.inc
+++ b/base.inc
@@ -1,6 +1,14 @@
 <?php
 // Common functions used by many/all pages
 
+// Handle exceptions in a user-friendly manner
+set_exception_handler('exception_handler');
+
+function exception_handler($exception)
+{
+    echo "Error: " . htmlspecialchars($exception->getMessage());
+}
+
 // Output valid HTML page header
 function output_header($header="", $addl_links=[], $js="")
 {
@@ -115,4 +123,71 @@ function log_tool_access($tool, $upid, $work="t")
         date('Y-m-d H:i:s'), $tool, $upid, $ip, $city, $country
     );
     file_put_contents($work . "/access.log", $s, FILE_APPEND);
+}
+
+class UploadError extends Exception {}
+
+function process_file_upload($formid, $workdir, $allowed_extensions=[])
+{
+    if(!isset($_FILES[$formid]) || !$_FILES[$formid]["name"]) {
+        throw new UploadError("No file was uploaded");
+    }
+
+    // get the information about the file
+    $file_name = $_FILES[$formid]['name'];
+    $file_size = $_FILES[$formid]['size'];
+    $file_tmp = $_FILES[$formid]['tmp_name'];
+    $file_type = $_FILES[$formid]['type'];
+
+    // lowercase the extension
+    $file_ext = strtolower(pathinfo($file_name, PATHINFO_EXTENSION));
+
+    // restrict basename to alphanumeric, -, or _ after replacing spaces
+    // with _
+    $file_basename = pathinfo($file_name, PATHINFO_FILENAME);
+    $file_basename = preg_replace("/\s+/", "_", $file_basename);
+    $file_basename = preg_replace("/[^-_a-zA-Z0-9]/", "", $file_basename);
+    if(!$file_basename) {
+        throw new UploadError("Filename did not contain any valid characters");
+    }
+
+    $final_filepath = "$workdir/$file_basename.$file_ext";
+    if(move_uploaded_file($file_tmp, $final_filepath) === FALSE) {
+        throw new UploadError("error moving uploaded file to working directory");
+    }
+
+    // begin a series of validation tests
+    try {
+        // does it pass the anti-virus tests?
+        $av_test_result = array();
+        $av_retval = 0;
+        $cmd = "/usr/bin/clamdscan '" . escapeshellcmd($final_filepath) . "'";
+        exec($cmd, $av_test_result, $av_retval);
+        if ($av_retval == 1) {
+            throw new UploadError("file rejected by AV scanner");
+        }
+
+        // was a file uploaded?
+        if ($_FILES[$formid]['size'] == 0) {
+            throw new UploadError("no file was uploaded");
+        }
+
+        // do they claim it's an allowed type?
+        if ($allowed_extensions && in_array($file_ext, $allowed_extensions) === false) {
+            throw new UploadError(
+                sprintf("file must have a %s extension", join(" or ", $allowed_extensions))
+            );
+        }
+
+        // is it small enough?
+        if ($file_size > 31457280) {
+            throw new UploadError("file size must be less than 30 MB");
+        }
+    } catch(Exception $e) {
+        unlink($final_filepath);
+        rmdir($workdir);
+        throw $e;
+    }
+
+    return $final_filepath;
 }

--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -190,34 +190,7 @@ if(isset($_POST['txt-cleanup-type'])){
 
 // ----- no errors. proceed ----------------------------------------
 
-// make a record of this attempted run ---
-// format is:
-//    2019-04-02 12:46:44 pphtml r5ca0b6b499bec \
-//    67.161.200.103 [Littleton, United States]
-
-$date = date('Y-m-d H:i:s');
-$ip = getUserIP();
-
-$access_key = 'f00ad0e10a4ebe4ec5cb3ffd6c1dc4c8';
-
-// Initialize CURL:
-$ch = curl_init('http://api.ipstack.com/'.$ip.'?access_key='.$access_key.'');
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-// Store the data:
-$json = curl_exec($ch);
-curl_close($ch);
-
-// Decode JSON response:
-$api_result = json_decode($json, true);
-
-// from: https://ipstack.com/documentation
-$city = $api_result['city'];
-$country = $api_result['country_name'];
-
-$messagegeo = " [" . $city . ", " . $country . "]";
-$s = $date . " " . "ppcomp" . " " . $upid . " " . $ip . $messagegeo . "\n";
-file_put_contents($work . "/access.log", $s, FILE_APPEND);
+log_tool_access("ppcomp", $upid);
 
 // ----- run the ppcomp command ----------------------------------------
 

--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -1,13 +1,8 @@
 <?php
 require_once("base.inc");
 
-$work = "t"; // a working folder for project data
-$upid = uniqid('r'); // unique project id
+list($workdir, $upid) = init_workdir();
 $options = "";  // user-requested options
-
-// create a unique workbench project folder in t
-$workdir = "$work/$upid";
-mkdir($workdir, 0755);
 
 // ----- process the first file ---------------------------------
 
@@ -86,10 +81,10 @@ log_tool_access("ppcomp", $upid);
 // ----- run the ppcomp command ----------------------------------------
 
 $scommand = 'PYTHONIOENCODING=utf-8:surrogateescape /home/rfrank/env/bin/python3 ./bin/comp_pp.py ' . $options . " " . $target_name1 . " " . $target_name2;
-$command = escapeshellcmd($scommand) . " > " . $work . "/" . $upid . "/result.html 2>&1";
+$command = escapeshellcmd($scommand) . " > " . $workdir . "/result.html 2>&1";
 
 // echo $command;
-file_put_contents("${work}/${upid}/command.txt", $command);
+file_put_contents("$workdir/command.txt", $command);
 
 $output = shell_exec($command);
 
@@ -100,8 +95,8 @@ output_header("ppcomp Results");
 $reportok = false;
 
 echo "<p>";
-if (file_exists("${work}/${upid}/result.html")) {
-   echo "results available: <a href='${work}/${upid}/result.html'>here</a>.<br/>";
+if (file_exists("$workdir/result.html")) {
+   echo "results available: <a href='$workdir/result.html'>here</a>.<br/>";
    $reportok = true;
 }
 if ($reportok) {

--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -1,130 +1,21 @@
 <?php
 require_once("base.inc");
 
-$errors = array(); // place to save error messages
 $work = "t"; // a working folder for project data
 $upid = uniqid('r'); // unique project id
 $options = "";  // user-requested options
 
-// in directory /tmp
-$tfilename1 = "/tmp/" . $upid . "-1";
-$tfilename2 = "/tmp/" . $upid . "-2";
-
-// in project folder
-$target_name1 = "";
-$target_name2 = "";
-
 // create a unique workbench project folder in t
-mkdir($work . "/" . $upid, 0755);
+$workdir = "$work/$upid";
+mkdir($workdir, 0755);
 
 // ----- process the first file ---------------------------------
 
-if (isset($_FILES['userfile1']) && $_FILES['userfile1']['name'] != "") {
-
-    // get the information about the file
-    $file_name = $_FILES['userfile1']['name'];
-    $file_size = $_FILES['userfile1']['size'];
-    $file_tmp = $_FILES['userfile1']['tmp_name'];
-    $file_type = $_FILES['userfile1']['type'];
-    $file_ext = pathinfo($file_name, PATHINFO_EXTENSION);
-    move_uploaded_file($file_tmp, $tfilename1);
-
-    // begin a series of validation tests
-
-    // does it pass the anti-virus tests?
-    $av_test_result = array();
-    $av_retval = 0;
-    $cmd = "/usr/bin/clamdscan " . escapeshellcmd($tfilename1);
-    exec($cmd, $av_test_result, $av_retval);
-    if ($av_retval == 1) {
-        $errors[] = "input file 1 rejected by clamdscan";
-        // destroy uploaded file
-        unlink( escapeshellcmd($tfilename1) );
-    }
-
-    // was a file uploaded?
-    if ($_FILES['userfile1']['size'] == 0) {
-        $errors[] = 'no file was uploaded';
-    }
-
-    // is it small enough?
-    if ($file_size > 31457280) {
-        $errors[] = "file size must be less than 30 MB";
-    }
-
-    // if any errors, report and terminate
-    if (empty($errors) == false) {
-        echo "<pre>";
-        echo "process terminated during processing uploaded file:<br/>";
-        foreach ($errors as $key => $value) {
-            echo $value . "<br/>";
-        }
-        echo "</pre>";
-        exit(1);
-    }
-
-    // move the uploaded file to the project folder
-    $target_name1 = $work . "/" . $upid . "/" . $file_name;
-    rename($tfilename1, $target_name1);
-} else {
-  echo "missing filename 1";
-  exit(1);
-}
-
+$target_name1 = process_file_upload("userfile1", $workdir);
 
 // ----- process the second file ---------------------------------
 
-if (isset($_FILES['userfile2']) && $_FILES['userfile2']['name'] != "") {
-
-    // get the information about the file
-    $file_name = $_FILES['userfile2']['name'];
-    $file_size = $_FILES['userfile2']['size'];
-    $file_tmp = $_FILES['userfile2']['tmp_name'];
-    $file_type = $_FILES['userfile2']['type'];
-    $file_ext = pathinfo($file_name, PATHINFO_EXTENSION);
-    move_uploaded_file($file_tmp, $tfilename2);
-
-    // begin a series of validation tests
-
-    // does it pass the anti-virus tests?
-    $av_test_result = array();
-    $av_retval = 0;
-    $cmd = "/usr/bin/clamdscan " . escapeshellcmd($tfilename2);
-    exec($cmd, $av_test_result, $av_retval);
-    if ($av_retval == 1) {
-        $errors[] = "input file 2 rejected by clamdscan";
-        // destroy uploaded file
-        unlink( escapeshellcmd($tfilename2) );
-    }
-
-    // was a file uploaded?
-    if ($_FILES['userfile2']['size'] == 0) {
-        $errors[] = 'no file was uploaded';
-    }
-
-    // is it small enough?
-    if ($file_size > 31457280) {
-        $errors[] = "file size must be less than 30 MB";
-    }
-
-    // if any errors, report and terminate
-    if (empty($errors) == false) {
-        echo "<pre>";
-        echo "process terminated during processing uploaded file:<br/>";
-        foreach ($errors as $key => $value) {
-            echo $value . "<br/>";
-        }
-        echo "</pre>";
-        exit(1);
-    }
-
-    // move the uploaded file to the project folder
-    $target_name2 = $work . "/" . $upid . "/" . $file_name;
-    rename($tfilename2, $target_name2);
-} else {
-  echo "missing filename 2";
-  exit(1);
-}
+$target_name2 = process_file_upload("userfile2", $workdir);
 
 // ----- process user options ---------------------------------------
 

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -1,75 +1,20 @@
 <?php
 require_once("base.inc");
 
-$errors = array(); // place to save error messages
 $work = "t"; // a working folder for project data
 $upid = uniqid('r'); // unique project id
 $extensions = array( // allowed file extensions
     "zip"
 );
-$target_name = "";
-$gtarget_name = "";
 
 // create a unique workbench project folder in t
-mkdir($work . "/" . $upid, 0755);
-
+$workdir = "$work/$upid";
+mkdir($workdir, 0755);
 
 // ----- process the main project file ---------------------------------
 
-if (isset($_FILES['userfile']) && $_FILES['userfile']['name'] != "") {
+$target_name = process_file_upload("userfile", $workdir, $extensions);
 
-    // get the information about the file
-    $file_name = $_FILES['userfile']['name'];
-    $file_size = $_FILES['userfile']['size'];
-    $file_tmp = $_FILES['userfile']['tmp_name'];
-    $file_type = $_FILES['userfile']['type'];
-    $file_ext = pathinfo($file_name, PATHINFO_EXTENSION);
-    move_uploaded_file($file_tmp, "/tmp/" . $upid);
-
-    // begin a series of validation tests
-
-    // does it pass the anti-virus tests?
-    $av_test_result = array();
-    $av_retval = 0;
-    $cmd = "/usr/bin/clamdscan " . escapeshellcmd("/tmp/" . $upid);
-    exec($cmd, $av_test_result, $av_retval);
-    if ($av_retval == 1) {
-        $errors[] = "input file rejected by clamdscan";
-        // destroy uploaded file
-        unlink( escapeshellcmd("/tmp/" . $upid) );
-    }
-
-    // was a file uploaded?
-    if ($_FILES['userfile']['size'] == 0) {
-        $errors[] = 'no file was uploaded';
-    }
-
-    // do they claim it's an allowed type?
-    if (in_array($file_ext, $extensions) === false) {
-        $errors[] = "please upload a .zip file";
-    }
-
-    // is it small enough?
-    if ($file_size > 40000000) {
-        $errors[] = "file size must be less than 40 MB";
-    }
-
-    // if any errors, report and terminate
-    if (empty($errors) == false) {
-        echo "<pre>";
-        echo "process terminated during processing uploaded file:<br/>";
-        foreach ($errors as $key => $value) {
-            echo $value . "<br/>";
-        }
-        echo "</pre>";
-        exit(1);
-    }
-
-    // move the uploaded file to the project folder
-    $target_name = $work . "/" . $upid . "/" . $file_name;
-    rename("/tmp/" . $upid, $target_name);
-}
-  
 // ----- no errors. proceed ----------------------------------------
 
 log_tool_access("pphtml", $upid);

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -1,15 +1,8 @@
 <?php
 require_once("base.inc");
 
-$work = "t"; // a working folder for project data
-$upid = uniqid('r'); // unique project id
-$extensions = array( // allowed file extensions
-    "zip"
-);
-
-// create a unique workbench project folder in t
-$workdir = "$work/$upid";
-mkdir($workdir, 0755);
+list($workdir, $upid) = init_workdir();
+$extensions = ["zip"]; // allowed file extensions
 
 // ----- process the main project file ---------------------------------
 
@@ -24,7 +17,7 @@ log_tool_access("pphtml", $upid);
 $zipArchive = new ZipArchive();
 $result = $zipArchive->open($target_name);
 if ($result === TRUE) {
-    $zipArchive->extractTo($work . "/" . $upid);
+    $zipArchive->extractTo($workdir);
     $zipArchive->close();
 }
 else {
@@ -34,8 +27,8 @@ else {
 
 // find the name of the user's HTML file. only one allowed
 
-$fileList1 = glob($work . "/" . $upid . '/*.htm');
-$fileList2 = glob($work . "/" . $upid . '/*.html');
+$fileList1 = glob("$workdir/*.htm");
+$fileList2 = glob("$workdir/*.html");
 $user_htmlfile = "";
 if (count($fileList1) == 1) {
     $user_htmlfile = $fileList1[0];
@@ -57,14 +50,14 @@ if(isset($_POST['ver']) && $_POST['ver'] == 'Yes') {
 // ----- run the pphtml command ----------------------------------------
 
 // build the command
-// $scommand = './pphtml -i ' . $target_name . ' -o ' . $work . "/" . $upid; // orthogonal
-// $scommand = './bin/pphtml -i ' . $user_htmlfile . ' -o ' . $work . "/" . $upid . "/report.html";
-$scommand = 'python3 ./bin/pphtml.py ' . $verbose . ' -i "' . $user_htmlfile . '" -o ' . $work . "/" . $upid . "/report.html";
+// $scommand = './pphtml -i ' . $target_name . ' -o ' . $workdir; // orthogonal
+// $scommand = './bin/pphtml -i ' . $user_htmlfile . ' -o ' . $workdir . "/report.html";
+$scommand = 'python3 ./bin/pphtml.py ' . $verbose . ' -i "' . $user_htmlfile . '" -o ' . $workdir . "/report.html";
 
 $command = escapeshellcmd($scommand) . " 2>&1";
 
 // echo $command;
-file_put_contents("${work}/${upid}/command.txt", $command);
+file_put_contents("$workdir/command.txt", $command);
 
 // and finally, run pphtml
 $output = shell_exec($command);
@@ -76,8 +69,8 @@ output_header("pphtml Results");
 $reportok = false;
 
 echo "<p>";
-if (file_exists("${work}/${upid}/report.html")) {
-   echo "results available: <a href='${work}/${upid}/report.html'>here</a>.<br/>";
+if (file_exists("$workdir/report.html")) {
+   echo "results available: <a href='$workdir/report.html'>here</a>.<br/>";
    $reportok = true;
 }
 if ($reportok) {

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -72,34 +72,7 @@ if (isset($_FILES['userfile']) && $_FILES['userfile']['name'] != "") {
   
 // ----- no errors. proceed ----------------------------------------
 
-// make a record of this attempted run ---
-// format is:
-//    2019-04-02 12:46:44 pphtml r5ca0b6b499bec \
-//    67.161.200.103 [Littleton, United States]
-
-$date = date('Y-m-d H:i:s');
-$ip = getUserIP();
-
-$access_key = 'f00ad0e10a4ebe4ec5cb3ffd6c1dc4c8';
-
-// Initialize CURL:
-$ch = curl_init('http://api.ipstack.com/'.$ip.'?access_key='.$access_key.'');
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-// Store the data:
-$json = curl_exec($ch);
-curl_close($ch);
-
-// Decode JSON response:
-$api_result = json_decode($json, true);
-
-// from: https://ipstack.com/documentation
-$city = $api_result['city'];
-$country = $api_result['country_name'];
-
-$messagegeo = " [" . $city . ", " . $country . "]";
-$s = $date . " " . "pphtml" . " " . $upid . " " . $ip . $messagegeo . "\n";
-file_put_contents($work . "/access.log", $s, FILE_APPEND);
+log_tool_access("pphtml", $upid);
 
 // ----- burst the zip file --------------------------------------------
 

--- a/ppsmq-action.php
+++ b/ppsmq-action.php
@@ -1,75 +1,20 @@
 <?php
 require_once("base.inc");
 
-$errors = array(); // place to save error messages
 $work = "t"; // a working folder for project data
 $upid = uniqid('r'); // unique project id
 $extensions = array( // allowed file extensions
     "txt","htm","html"
 );
-$target_name = "";
-$gtarget_name = "";
 
 // create a unique workbench project folder in t
-mkdir($work . "/" . $upid, 0755);
-
+$workdir = "$work/$upid";
+mkdir($workdir, 0755);
 
 // ----- process the main project file ---------------------------------
 
-if (isset($_FILES['userfile']) && $_FILES['userfile']['name'] != "") {
+$target_name = process_file_upload("userfile", $workdir, $extensions);
 
-    // get the information about the file
-    $file_name = $_FILES['userfile']['name'];
-    $file_size = $_FILES['userfile']['size'];
-    $file_tmp = $_FILES['userfile']['tmp_name'];
-    $file_type = $_FILES['userfile']['type'];
-    $file_ext = pathinfo($file_name, PATHINFO_EXTENSION);
-    move_uploaded_file($file_tmp, "/tmp/" . $upid);
-
-    // begin a series of validation tests
-
-    // does it pass the anti-virus tests?
-    $av_test_result = array();
-    $av_retval = 0;
-    $cmd = "/usr/bin/clamdscan " . escapeshellcmd("/tmp/" . $upid);
-    exec($cmd, $av_test_result, $av_retval);
-    if ($av_retval == 1) {
-        $errors[] = "input file rejected by clamdscan";
-        // destroy uploaded file
-        unlink( escapeshellcmd("/tmp/" . $upid) );
-    }
-
-    // was a file uploaded?
-    if ($_FILES['userfile']['size'] == 0) {
-        $errors[] = 'no file was uploaded';
-    }
-
-    // do they claim it's an allowed type?
-    if (in_array($file_ext, $extensions) === false) {
-        $errors[] = "please upload a .txt file";
-    }
-
-    // is it small enough?
-    if ($file_size > 31457280) {
-        $errors[] = "file size must be less than 30 MB";
-    }
-
-    // if any errors, report and terminate
-    if (empty($errors) == false) {
-        echo "<pre>";
-        echo "process terminated during processing uploaded file:<br/>";
-        foreach ($errors as $key => $value) {
-            echo $value . "<br/>";
-        }
-        echo "</pre>";
-        exit(1);
-    }
-
-    // move the uploaded file to the project folder
-    $target_name = $work . "/" . $upid . "/" . $file_name;
-    rename("/tmp/" . $upid, $target_name);
-}
- 
 // ----- no errors. proceed ----------------------------------------
 
 log_tool_access("ppsmq", $upid);

--- a/ppsmq-action.php
+++ b/ppsmq-action.php
@@ -1,15 +1,8 @@
 <?php
 require_once("base.inc");
 
-$work = "t"; // a working folder for project data
-$upid = uniqid('r'); // unique project id
-$extensions = array( // allowed file extensions
-    "txt","htm","html"
-);
-
-// create a unique workbench project folder in t
-$workdir = "$work/$upid";
-mkdir($workdir, 0755);
+list($workdir, $upid) = init_workdir();
+$extensions = ["txt", "htm", "html"]; // allowed file extensions
 
 // ----- process the main project file ---------------------------------
 
@@ -22,7 +15,7 @@ log_tool_access("ppsmq", $upid);
 // ----- run the ppsmq command ----------------------------------------
 
 // build the command
-$scommand = 'python3 ./bin/ppsmq.py -i ' . $target_name . ' -o ' . $work . '/' . $upid . '/report.txt';
+$scommand = 'python3 ./bin/ppsmq.py -i ' . $target_name . ' -o ' . $workdir . '/report.txt';
 $command = escapeshellcmd($scommand) . " 2>&1";
 // echo $command;
 
@@ -36,8 +29,8 @@ output_header("ppsmq Results");
 $reportok = false;
 
 echo "<p>";
-if (file_exists("${work}/${upid}/report.txt")) {
-   echo "results available: <a href='${work}/${upid}/report.txt'>here</a>.<br/>";
+if (file_exists("$workdir/report.txt")) {
+   echo "results available: <a href='$workdir/report.txt'>here</a>.<br/>";
    $reportok = true;
 }
 if ($reportok) {

--- a/ppsmq-action.php
+++ b/ppsmq-action.php
@@ -72,34 +72,7 @@ if (isset($_FILES['userfile']) && $_FILES['userfile']['name'] != "") {
  
 // ----- no errors. proceed ----------------------------------------
 
-// make a record of this attempted run ---
-// format is:
-//    2019-03-31 12:46:44  ppsmq r5ca0b6b499bec \
-//    67.161.200.103 [Littleton, United States]
-
-$date = date('Y-m-d H:i:s');
-$ip = getUserIP();
-
-$access_key = 'f00ad0e10a4ebe4ec5cb3ffd6c1dc4c8';
-
-// Initialize CURL:
-$ch = curl_init('http://api.ipstack.com/'.$ip.'?access_key='.$access_key.'');
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-// Store the data:
-$json = curl_exec($ch);
-curl_close($ch);
-
-// Decode JSON response:
-$api_result = json_decode($json, true);
-
-// from: https://ipstack.com/documentation
-$city = $api_result['city'];
-$country = $api_result['country_name'];
-
-$messagegeo = " [" . $city . ", " . $country . "]";
-$s = $date . " " . " ppsmq" . " " . $upid . " " . $ip . $messagegeo . "\n";
-file_put_contents($work . "/access.log", $s, FILE_APPEND);
+log_tool_access("ppsmq", $upid);
 
 // ----- run the ppsmq command ----------------------------------------
 

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -1,131 +1,28 @@
 <?php
 require_once("base.inc");
 
-$errors = array(); // place to save error messages
 $work = "t"; // a working folder for project data
 $upid = uniqid('r'); // unique project id
 $extensions = array( // allowed file extensions
     "txt", "TXT"
 );
-$target_name = "";
-$gtarget_name = "";
 
 // create a unique workbench project folder in t
-mkdir($work . "/" . $upid, 0755);
-
+$workdir = "$work/$upid";
+mkdir($workdir, 0755);
 
 // ----- process the main project file ---------------------------------
 
-if (isset($_FILES['userfile']) && $_FILES['userfile']['name'] != "") {
-
-    // get the information about the file
-    $file_name = $_FILES['userfile']['name'];
-    $file_size = $_FILES['userfile']['size'];
-    $file_tmp = $_FILES['userfile']['tmp_name'];
-    $file_type = $_FILES['userfile']['type'];
-    $file_ext = pathinfo($file_name, PATHINFO_EXTENSION);
-    move_uploaded_file($file_tmp, "/tmp/" . $upid);
-
-    // begin a series of validation tests
-
-    // does it pass the anti-virus tests?
-    $av_test_result = array();
-    $av_retval = 0;
-    $cmd = "/usr/bin/clamdscan " . escapeshellcmd("/tmp/" . $upid);
-    exec($cmd, $av_test_result, $av_retval);
-    if ($av_retval == 1) {
-        $errors[] = "input file rejected by clamdscan";
-        // destroy uploaded file
-        unlink( escapeshellcmd("/tmp/" . $upid) );
-    }
-
-    // was a file uploaded?
-    if ($_FILES['userfile']['size'] == 0) {
-        $errors[] = 'no file was uploaded';
-    }
-
-    // do they claim it's an allowed type?
-    if (in_array($file_ext, $extensions) === false) {
-        $errors[] = "please upload a .txt file";
-    }
-
-    // is it small enough?
-    if ($file_size > 31457280) {
-        $errors[] = "file size must be less than 30 MB";
-    }
-
-    // if any errors, report and terminate
-    if (empty($errors) == false) {
-        echo "<pre>";
-        echo "process terminated during processing uploaded file:<br/>";
-        foreach ($errors as $key => $value) {
-            echo $value . "<br/>";
-        }
-        echo "</pre>";
-        exit(1);
-    }
-
-    // move the uploaded file to the project folder
-    $target_name = $work . "/" . $upid . "/" . $file_name;
-    rename("/tmp/" . $upid, $target_name);
-}
+$target_name = process_file_upload("userfile", $workdir, $extensions);
 
 // ----- do that all again for the goodwords file, if present ------
 
-if (isset($_FILES['goodfile']) && $_FILES['goodfile']['name'] != "") {
-
-    // get the information about the file
-    $file_name = $_FILES['goodfile']['name'];
-    $file_size = $_FILES['goodfile']['size'];
-    $file_tmp = $_FILES['goodfile']['tmp_name'];
-    $file_type = $_FILES['goodfile']['type'];
-    $file_ext = pathinfo($file_name, PATHINFO_EXTENSION);
-    move_uploaded_file($file_tmp, "/tmp/" . $upid);
-
-    // begin a series of validation tests
-
-    // does it pass the anti-virus tests?
-    $av_test_result = array();
-    $av_retval = 0;
-    $cmd = "/usr/bin/clamdscan " . escapeshellcmd("/tmp/" . $upid);
-    exec($cmd, $av_test_result, $av_retval);
-    if ($av_retval == 1) {
-        $errors[] = "input file rejected by clamdscan";
-        // destroy uploaded file
-        unlink( escapeshellcmd("/tmp/" . $upid) );
-    }
-
-    // was a file uploaded?
-    if ($_FILES['userfile']['size'] == 0) {
-        $errors[] = 'no file was uploaded';
-    }
-
-    // do they claim it's an allowed type?
-    if (in_array($file_ext, $extensions) === false) {
-        $errors[] = "please upload a .txt file";
-    }
-
-    // is it small enough?
-    if ($file_size > 31457280) {
-        $errors[] = "file size must be less than 30 MB";
-    }
-
-    // if any errors, report and terminate
-    if (empty($errors) == false) {
-        echo "<pre>";
-        echo "process terminated during processing good words file:<br/>";
-        foreach ($errors as $key => $value) {
-            echo $value . "<br/>";
-        }
-        echo "</pre>";
-        exit(1);
-    }
-
-    // move the uploaded file to the project folder
-    $gtarget_name = $work . "/" . $upid . "/" . $file_name;
-    rename("/tmp/" . $upid, $gtarget_name);
+if (@$_FILES['goodfile']["name"]) {
+    $gtarget_name = process_file_upload("goodfile", $workdir, $extensions);
+} else {
+    $gtarget_name = "";
 }
-  
+
 // ----- no errors. proceed ----------------------------------------
 
 log_tool_access("pptext", $upid);

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -1,15 +1,8 @@
 <?php
 require_once("base.inc");
 
-$work = "t"; // a working folder for project data
-$upid = uniqid('r'); // unique project id
-$extensions = array( // allowed file extensions
-    "txt", "TXT"
-);
-
-// create a unique workbench project folder in t
-$workdir = "$work/$upid";
-mkdir($workdir, 0755);
+list($workdir, $upid) = init_workdir();
+$extensions = ["txt", "TXT"]; // allowed file extensions
 
 // ----- process the main project file ---------------------------------
 
@@ -40,7 +33,7 @@ if ($target_name != "") {
         $cmd = "iconv -f ISO_8859-1 -t UTF-8 -o '${tmpfname}' '${target_name}'";
         exec($cmd, $ppf_output, $ppf_exitcode);
         rename($tmpfname, $target_name);
-        file_put_contents("${work}/${upid}/converted-main.txt", "text file converted from ISO-8859");
+        file_put_contents("$workdir/converted-main.txt", "text file converted from ISO-8859");
     }
 }
 
@@ -55,7 +48,7 @@ if ($gtarget_name != "") {
         $cmd = "iconv -f ISO_8859-1 -t UTF-8 -o '${tmpfname}' '${gtarget_name}'";
         exec($cmd, $ppf_outputg, $ppf_exitcodeg);
         rename($tmpfname, $gtarget_name);
-        file_put_contents("${work}/${upid}/converted-gwf.txt", "good words file converted from ISO-8859");
+        file_put_contents("$workdir/converted-gwf.txt", "good words file converted from ISO-8859");
     }
 }
 
@@ -132,11 +125,11 @@ if ($gtarget_name != "") {
 // ----- run the pptext command ----------------------------------------
 
 // build the command
-$scommand = './bin/pptext ' . $useropts . $gw . ' -i "' . $target_name . '" -o ' . $work . "/" . $upid;
+$scommand = './bin/pptext ' . $useropts . $gw . ' -i "' . $target_name . '" -o ' . $workdir;
 $command = escapeshellcmd($scommand) . " 2>&1";
 
 // echo $command;
-file_put_contents("${work}/${upid}/command.txt", $command);
+file_put_contents("$workdir/command.txt", $command);
 
 // and finally, run pptext
 $output = shell_exec($command);
@@ -148,12 +141,12 @@ output_header("pptext Results");
 $reportok = false;
 
 echo "<p>";
-if (file_exists("${work}/${upid}/report.html")) {
-   echo "results available: <a href='${work}/${upid}/report.html'>here</a>.<br/>";
+if (file_exists("$workdir/report.html")) {
+   echo "results available: <a href='$workdir/report.html'>here</a>.<br/>";
    $reportok = true;
 }
-if (file_exists("${work}/${upid}/scanreport.txt")) {
-   echo "punctuation scan report: <a href='${work}/${upid}/scanreport.txt'>here</a>.<br/>";
+if (file_exists("$workdir/scanreport.txt")) {
+   echo "punctuation scan report: <a href='$workdir/scanreport.txt'>here</a>.<br/>";
    $reportok = true;
 }
 if ($reportok) {

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -128,34 +128,7 @@ if (isset($_FILES['goodfile']) && $_FILES['goodfile']['name'] != "") {
   
 // ----- no errors. proceed ----------------------------------------
 
-// make a record of this attempted run ---
-// format is:
-//    2019-03-31 12:46:44 pptext r5ca0b6b499bec \
-//    67.161.200.103 [Littleton, United States]
-
-$date = date('Y-m-d H:i:s');
-$ip = getUserIP();
-
-$access_key = 'f00ad0e10a4ebe4ec5cb3ffd6c1dc4c8';
-
-// Initialize CURL:
-$ch = curl_init('http://api.ipstack.com/'.$ip.'?access_key='.$access_key.'');
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-// Store the data:
-$json = curl_exec($ch);
-curl_close($ch);
-
-// Decode JSON response:
-$api_result = json_decode($json, true);
-
-// from: https://ipstack.com/documentation
-$city = $api_result['city'];
-$country = $api_result['country_name'];
-
-$messagegeo = " [" . $city . ", " . $country . "]";
-$s = $date . " " . "pptext" . " " . $upid . " " . $ip . $messagegeo . "\n";
-file_put_contents($work . "/access.log", $s, FILE_APPEND);
+log_tool_access("pptext", $upid);
 
 // ----- user has option of uploading a Latin-1 file -------------------
 


### PR DESCRIPTION
Move more common functionality to `base.inc`. In three separate commits:
1. access logging
2. upload processing
3. workdir init

#2 is the most important because it means we only have one spot where we need to ensure our upload process is secure rather than 4. The upload logic was hardened to strip out non-[alphanumeric, -, _] characters to prevent possibly-malicious filenames.

This is testable in the [more-common-functions](https://www.pgdp.org/~cpeel/ppwb.branch/more-common-functions/index.php) sandbox.

The diffstat of this MR is very satisfying:
```
 base.inc          |  113 +++++++++++++++++++++++++++++++++++
 ppcomp-action.php |  159 ++------------------------------------------------
 pphtml-action.php |  117 ++++--------------------------------
 ppsmq-action.php  |  103 ++------------------------------
 pptext-action.php |  171 +++++-------------------------------------------------
 5 files changed, 160 insertions(+), 503 deletions(-)
```