### PR TITLE
Better command escaping

### DIFF
--- a/base.inc
+++ b/base.inc
@@ -203,3 +203,22 @@ function process_file_upload($formid, $workdir, $allowed_extensions=[])
 
     return $final_filepath;
 }
+
+// If a text file is ISO-8859 convert it to UTF-8
+// Returns true if a conversion was necessary, else false
+function ensure_utf8_file($filename) {
+    $cmd = sprintf("file %s", escapeshellarg($filename));
+    exec($cmd, $ppf_output, $ppf_exitcode);
+    if (strpos($ppf_output[0], "ISO-8859") !== false) {
+        // Latin-1. convert to UTF-8
+        $tmpfname = "$filename.tmp";
+        $cmd = sprintf("iconv -f ISO_8859-1 -t UTF-8 -o %s %s",
+            escapeshellarg($tmpfname), escapeshellarg($filename)
+        );
+        exec(escapeshellcmd($cmd), $ppf_output, $ppf_exitcode);
+        rename($tmpfname, $filename);
+        return true;
+    }
+    return false;
+}
+

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -41,20 +41,28 @@ if ($user_htmlfile == "") {
     exit(1);       
 }
 
+$options = [];
+
 // see if user has ticked the "verbose" box
-$verbose = "";
 if(isset($_POST['ver']) && $_POST['ver'] == 'Yes') {
-    $verbose = " -v ";
+    $options[] = "-v";
 }
 
 // ----- run the pphtml command ----------------------------------------
 
 // build the command
-// $scommand = './pphtml -i ' . $target_name . ' -o ' . $workdir; // orthogonal
-// $scommand = './bin/pphtml -i ' . $user_htmlfile . ' -o ' . $workdir . "/report.html";
-$scommand = 'python3 ./bin/pphtml.py ' . $verbose . ' -i "' . $user_htmlfile . '" -o ' . $workdir . "/report.html";
+$scommand = join(" ", [
+    "python3",
+    "./bin/pphtml.py",
+    join(" ", $options),
+    "-i " . escapeshellarg($user_htmlfile),
+    "-o " . escapeshellarg("$workdir/report.html")
+]);
 
-$command = escapeshellcmd($scommand) . " 2>&1";
+$command = join(" ", [
+    escapeshellcmd($scommand),
+    "2>&1"
+]);
 
 // echo $command;
 file_put_contents("$workdir/command.txt", $command);

--- a/ppsmq-action.php
+++ b/ppsmq-action.php
@@ -15,8 +15,18 @@ log_tool_access("ppsmq", $upid);
 // ----- run the ppsmq command ----------------------------------------
 
 // build the command
-$scommand = 'python3 ./bin/ppsmq.py -i ' . $target_name . ' -o ' . $workdir . '/report.txt';
-$command = escapeshellcmd($scommand) . " 2>&1";
+$scommand = join(" ", [
+	"python3",
+	"./bin/ppsmq.py",
+	"-i " . escapeshellarg($target_name),
+	"-o " . escapeshellarg("$workdir/report.txt")
+]);
+
+$command = join(" ", [
+	escapeshellcmd($scommand),
+	"2>&1"
+]);
+
 // echo $command;
 
 // and finally, run ppsmq

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -23,33 +23,13 @@ log_tool_access("pptext", $upid);
 // ----- user has option of uploading a Latin-1 file -------------------
 
 // main file
-if ($target_name != "") {
-    $cmd = "file '${target_name}'";
-    exec($cmd, $ppf_output, $ppf_exitcode);
-    $pos = strpos($ppf_output[0], "ISO-8859");
-    if ($pos !== false) {
-        // Latin-1. convert to UTF-8
-        $tmpfname = "/tmp/trash01.txt";
-        $cmd = "iconv -f ISO_8859-1 -t UTF-8 -o '${tmpfname}' '${target_name}'";
-        exec($cmd, $ppf_output, $ppf_exitcode);
-        rename($tmpfname, $target_name);
-        file_put_contents("$workdir/converted-main.txt", "text file converted from ISO-8859");
-    }
+if(ensure_utf8_file($target_name)) {
+    file_put_contents("$workdir/converted-main.txt", "text file converted from ISO-8859\n");
 }
 
 // good words file
-if ($gtarget_name != "") {
-    $cmd = "file '${gtarget_name}'";
-    exec($cmd, $ppf_outputg, $ppf_exitcodeg);
-    $pos = strpos($ppf_outputg[0], "ISO-8859");
-    if ($pos !== false) {
-        // Latin-1. convert to UTF-8
-        $tmpfname = "/tmp/trash01.txt";
-        $cmd = "iconv -f ISO_8859-1 -t UTF-8 -o '${tmpfname}' '${gtarget_name}'";
-        exec($cmd, $ppf_outputg, $ppf_exitcodeg);
-        rename($tmpfname, $gtarget_name);
-        file_put_contents("$workdir/converted-gwf.txt", "good words file converted from ISO-8859");
-    }
+if ($gtarget_name && ensure_utf8_file($gtarget_name)) {
+    file_put_contents("$workdir/converted-gwf.txt", "good words file converted from ISO-8859\n");
 }
 
 // ----- process user options ------------------------------------------


### PR DESCRIPTION
This has two commits:
1. move Latin1 -> UTF8 logic to a single function in `base.inc`
2. standardize and ensure proper command escaping

#2 is the big one here and touches all of the action files. It ensures that all arguments originating from the user (via upload filename or page POST) are properly escaped.

In adjusting this I fixed the handling of jeebies for non-English languages in pptext. The code implied that jeebies should not be used with pptext if at least one of the languages wasn't English, but that part was not properly enforced -- it is now.

Testable in the [better-command-escaping](https://www.pgdp.org/~cpeel/ppwb.branch/better-command-escaping/) sandbox.