### PR TITLE
Use a config file to specify local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/pptext
 bin/hebelist.txt
 bin/pphtml.py
 bin/scannos.txt
+config.php

--- a/README.md
+++ b/README.md
@@ -14,3 +14,28 @@ The following two external tools need to be downloaded and installed
 in the `bin/` directory:
 * [pptext](https://github.com/DistributedProofreaders/pptext)
 * [pphtml](https://github.com/DistributedProofreaders/pphtml)
+
+## Python environment
+
+The external python programs require various python libraries to be installed
+in order to work. Consult with each of the tools' `requirements.txt` files
+for more details. These can be installed in the system's python3 installation
+or in a virtualenv dedicated for ppwb.
+
+If using a virtualenv, you will need to create a python proxy script to
+initialize the environment. For example:
+
+```bash
+#!/bin/bash
+
+VENV=/path/to/virtualenv/basedir/
+source $VENV/bin/activate
+
+python $*
+```
+
+Make this script executable and set it as your `$python_runner` in `config.php`.
+
+Ensure that the web server can access the virtualenv. virtualenvs created
+in `~/.local` may need to have the permissions updated (o+x) to allow the
+web server sufficient permissions.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ in the `bin/` directory:
 * [pptext](https://github.com/DistributedProofreaders/pptext)
 * [pphtml](https://github.com/DistributedProofreaders/pphtml)
 
+For ppcomp to work, `dwdiff` needs to be installed as well.
+
 ## Python environment
 
 The external python programs require various python libraries to be installed

--- a/base.inc
+++ b/base.inc
@@ -1,8 +1,38 @@
 <?php
-// Common functions used by many/all pages
+// This file is included at the top of every page. It sets up some common
+// infrastructure and defines some common functions.
 
 // Handle exceptions in a user-friendly manner
 set_exception_handler('exception_handler');
+
+//===========================================================================
+// Configuration
+
+// Define some global configuration values. These can be overridden in
+// an optional configuration file (config.php).
+
+// $base_workdir is where files are uploaded and where results are stored.
+// It must be writeable by the webserver and also needs to be accessible by
+// URL ($base_workurl). $base_workurl can be a relative or absolute URL to
+// where the workfiles can be accessed.
+global $base_workdir, $base_workurl;
+$base_workdir = "./t";
+$base_workurl = "./t";
+
+// $python_runner defines the python binary, or proxy script, to run the
+// python-based tools. See README.md for more information on setting up
+// the python tools.
+global $python_runner;
+$python_runner = "python3";
+
+// Load an (optional) configuration file
+if(is_file("config.php")) {
+    include("config.php");
+}
+
+
+//===========================================================================
+// Common functions used by many/all pages
 
 function exception_handler($exception)
 {
@@ -79,13 +109,16 @@ FOOT;
 // initialize a working directory to store uploaded and processed files
 function init_workdir()
 {
-    $work = "t";
+    global $base_workdir, $base_workurl;
+
     $upid = uniqid('r');
 
-    $workdir = "$work/$upid";
+    $workdir = "$base_workdir/$upid";
     mkdir($workdir, 0755);
 
-    return [$workdir, $upid];
+    $workurl = "$base_workurl/$upid";
+
+    return [$workdir, $workurl, $upid];
 }
 
 // get user's IP address
@@ -106,8 +139,10 @@ function getUserIP()
 }
 
 // log tool access
-function log_tool_access($tool, $upid, $work="t")
+function log_tool_access($tool, $upid)
 {
+    global $base_workdir;
+
     // make a record of this attempted run ---
     // format is:
     //    2019-03-31 12:46:44 pptext r5ca0b6b499bec \
@@ -134,7 +169,7 @@ function log_tool_access($tool, $upid, $work="t")
     $s = sprintf("%s %6s %s %s [%s, %s]\n",
         date('Y-m-d H:i:s'), $tool, $upid, $ip, $city, $country
     );
-    file_put_contents($work . "/access.log", $s, FILE_APPEND);
+    file_put_contents("$base_workdir/access.log", $s, FILE_APPEND);
 }
 
 class UploadError extends Exception {}

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,0 +1,6 @@
+# comp_pp.py requirements
+lxml
+tinycss
+cssselect
+
+# ppsmq.py has no requirements

--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -1,7 +1,7 @@
 <?php
 require_once("base.inc");
 
-list($workdir, $upid) = init_workdir();
+list($workdir, $workurl, $upid) = init_workdir();
 
 // ----- process the first file ---------------------------------
 
@@ -50,8 +50,7 @@ log_tool_access("ppcomp", $upid);
 // ----- run the ppcomp command ----------------------------------------
 
 $scommand = join(" ", [
-    "PYTHONIOENCODING=utf-8:surrogateescape",
-    "/home/rfrank/env/bin/python3",
+    $python_runner,
     "./bin/comp_pp.py",
     join(" ", $options),
     escapeshellarg($target_name1),
@@ -78,7 +77,7 @@ $reportok = false;
 
 echo "<p>";
 if (file_exists("$workdir/result.html")) {
-   echo "results available: <a href='$workdir/result.html'>here</a>.<br/>";
+   echo "results available: <a href='$workurl/result.html'>here</a>.<br/>";
    $reportok = true;
 }
 if ($reportok) {

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -1,7 +1,7 @@
 <?php
 require_once("base.inc");
 
-list($workdir, $upid) = init_workdir();
+list($workdir, $workurl, $upid) = init_workdir();
 $extensions = ["zip"]; // allowed file extensions
 
 // ----- process the main project file ---------------------------------
@@ -52,7 +52,7 @@ if(isset($_POST['ver']) && $_POST['ver'] == 'Yes') {
 
 // build the command
 $scommand = join(" ", [
-    "python3",
+    $python_runner,
     "./bin/pphtml.py",
     join(" ", $options),
     "-i " . escapeshellarg($user_htmlfile),
@@ -78,7 +78,7 @@ $reportok = false;
 
 echo "<p>";
 if (file_exists("$workdir/report.html")) {
-   echo "results available: <a href='$workdir/report.html'>here</a>.<br/>";
+   echo "results available: <a href='$workurl/report.html'>here</a>.<br/>";
    $reportok = true;
 }
 if ($reportok) {

--- a/ppsmq-action.php
+++ b/ppsmq-action.php
@@ -1,7 +1,7 @@
 <?php
 require_once("base.inc");
 
-list($workdir, $upid) = init_workdir();
+list($workdir, $workurl, $upid) = init_workdir();
 $extensions = ["txt", "htm", "html"]; // allowed file extensions
 
 // ----- process the main project file ---------------------------------
@@ -16,7 +16,7 @@ log_tool_access("ppsmq", $upid);
 
 // build the command
 $scommand = join(" ", [
-	"python3",
+	$python_runner,
 	"./bin/ppsmq.py",
 	"-i " . escapeshellarg($target_name),
 	"-o " . escapeshellarg("$workdir/report.txt")
@@ -40,7 +40,7 @@ $reportok = false;
 
 echo "<p>";
 if (file_exists("$workdir/report.txt")) {
-   echo "results available: <a href='$workdir/report.txt'>here</a>.<br/>";
+   echo "results available: <a href='$workurl/report.txt'>here</a>.<br/>";
    $reportok = true;
 }
 if ($reportok) {

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -1,7 +1,7 @@
 <?php
 require_once("base.inc");
 
-list($workdir, $upid) = init_workdir();
+list($workdir, $workurl, $upid) = init_workdir();
 $extensions = ["txt", "TXT"]; // allowed file extensions
 
 // ----- process the main project file ---------------------------------
@@ -118,11 +118,11 @@ $reportok = false;
 
 echo "<p>";
 if (file_exists("$workdir/report.html")) {
-   echo "results available: <a href='$workdir/report.html'>here</a>.<br/>";
+   echo "results available: <a href='$workurl/report.html'>here</a>.<br/>";
    $reportok = true;
 }
 if (file_exists("$workdir/scanreport.txt")) {
-   echo "punctuation scan report: <a href='$workdir/scanreport.txt'>here</a>.<br/>";
+   echo "punctuation scan report: <a href='$workurl/scanreport.txt'>here</a>.<br/>";
    $reportok = true;
 }
 if ($reportok) {


### PR DESCRIPTION
Allow the working directory, and URL, to be defined in a config file. Provide documentation on how to specify the python instance used to run the python tooling, including info on using a virtualenv.

This does a couple of very useful things from a site deployment perspective:
1. allows the use of a python virtualenv to run the python commands so that python packages don't need to be installed in the system python instance
2. allows the working directory to be located outside of the code-space

In the [config-dir](https://www.pgdp.org/~cpeel/ppwb.branch/config-file) sandbox, the following `config.php` file is used:
```php
<?php
global $python_runner;
$python_runner = "./pyvenv-proxy.sh";

global $base_workdir;
$base_workdir = "/data/htdocs/d/ppwb";

global $base_workurl;
$base_workurl = "/d/ppwb";
```

This places the results on TEST in the `/d` directory with other dynamically-generated files.