### PR TITLE
Use subdirs under bin/ for external tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 t
-bin/pptext
-bin/hebelist.txt
-bin/pphtml.py
-bin/scannos.txt
+bin/pptext/
+bin/pphtml/
 config.php

--- a/README.md
+++ b/README.md
@@ -10,10 +10,20 @@ text analysis (see `pptext.php`), HTML analysis (see `pphtml.php`),
 "smart quote" processing (see `ppsmq.php`) and a file compare tool
 (see `ppcomp.php`).
 
-The following two external tools need to be downloaded and installed
-in the `bin/` directory:
-* [pptext](https://github.com/DistributedProofreaders/pptext)
-* [pphtml](https://github.com/DistributedProofreaders/pphtml)
+The following two external tools need to be installed in directories under
+`bin/`:
+* [pptext](https://github.com/DistributedProofreaders/pptext) in `bin/pptext/`
+* [pphtml](https://github.com/DistributedProofreaders/pphtml) in `bin/pphtml/`
+
+It's recommended that you clone those repos into `bin/` directly:
+
+```bash
+cd bin
+git clone https://github.com/DistributedProofreaders/pptext.git
+git clone https://github.com/DistributedProofreaders/pphtml.git
+```
+
+See the individual tools' README.md for their prerequisites.
 
 For ppcomp to work, `dwdiff` needs to be installed as well.
 

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -53,7 +53,7 @@ if(isset($_POST['ver']) && $_POST['ver'] == 'Yes') {
 // build the command
 $scommand = join(" ", [
     $python_runner,
-    "./bin/pphtml.py",
+    "./bin/pphtml/pphtml.py",
     join(" ", $options),
     "-i " . escapeshellarg($user_htmlfile),
     "-o " . escapeshellarg("$workdir/report.html")

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -93,7 +93,7 @@ if ($gtarget_name) {
 
 // build the command
 $scommand = join(" ", [
-    "./bin/pptext",
+    "./bin/pptext/pptext",
     join(" ", $options),
     "-i " . escapeshellarg($target_name),
     "-o " . escapeshellarg($workdir)


### PR DESCRIPTION
After working to finalize a site ppwb instance on TEST I realized that changing how we manage the external tool repos could use a tweak.

For pptext and pphtml which come from external repositories, place them under subdirectories in bin/ such that they can simply be cloned. This will make it much easier to automate updates separately for ppwb, pptext, and pphtml.

Use this manual checkout process instead of git submodules because the latter are going to be too heavy-handed (and possibly a bit obscure to maintainers) for what is needed here.