### PR TITLE
Centralize tool logging

### DIFF
--- a/base.inc
+++ b/base.inc
@@ -197,6 +197,11 @@ function log_tool_access($tool, $upid)
     file_put_contents("$base_workdir/access.log", $s, FILE_APPEND);
 }
 
+function log_tool_action($workdir, $label, $message)
+{
+    file_put_contents("$workdir/messages.log", "$label: $message\n", FILE_APPEND);
+}
+
 class UploadError extends Exception {}
 
 function process_file_upload($formid, $workdir, $allowed_extensions=[])
@@ -261,6 +266,8 @@ function process_file_upload($formid, $workdir, $allowed_extensions=[])
         throw $e;
     }
 
+    log_tool_action($workdir, "uploaded file", $final_filepath);
+
     return $final_filepath;
 }
 
@@ -277,6 +284,7 @@ function ensure_utf8_file($filename) {
         );
         exec(escapeshellcmd($cmd), $ppf_output, $ppf_exitcode);
         rename($tmpfname, $filename);
+        log_tool_action(dirname($filename), "UTF-8 conversion", "$filename converted from ISO-8859-1");
         return true;
     }
     return false;

--- a/base.inc
+++ b/base.inc
@@ -243,6 +243,9 @@ function process_file_upload($formid, $workdir, $allowed_extensions=[])
         if ($av_retval == 1) {
             throw new UploadError("file rejected by AV scanner");
         }
+        if ($av_retval != 0) {
+            throw new UploadError("error running AV scanner");
+        }
 
         // was a file uploaded?
         if ($_FILES[$formid]['size'] == 0) {

--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -64,10 +64,11 @@ $command = join(" ", [
     "2>&1"
 ]);
 
-// echo $command;
-file_put_contents("$workdir/command.txt", $command);
+log_tool_action($workdir, "command", $command);
 
 $output = shell_exec($command);
+
+log_tool_action($workdir, "output", $output);
 
 // ----- display results -------------------------------------------
 
@@ -88,4 +89,3 @@ if ($reportok) {
     <tt>${output}</tt></p>
     </p>For more assistance, ask in the <a href='$help_url'>discussion topic</a> and include this identifier: ${upid}</p>";
 }
-

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -64,11 +64,12 @@ $command = join(" ", [
     "2>&1"
 ]);
 
-// echo $command;
-file_put_contents("$workdir/command.txt", $command);
+log_tool_action($workdir, "command", $command);
 
 // and finally, run pphtml
 $output = shell_exec($command);
+
+log_tool_action($workdir, "output", $output);
 
 // ----- display results -------------------------------------------
 
@@ -89,4 +90,3 @@ if ($reportok) {
     <tt>${output}</tt></p>
     </p>For more assistance, ask in the <a href='$help_url'>discussion topic</a> and include this identifier: ${upid}</p>";
 }
-

--- a/ppsmq-action.php
+++ b/ppsmq-action.php
@@ -27,10 +27,12 @@ $command = join(" ", [
     "2>&1"
 ]);
 
-// echo $command;
+log_tool_action($workdir, "command", $command);
 
 // and finally, run ppsmq
 $output = shell_exec($command);
+
+log_tool_action($workdir, "output", $output);
 
 // ----- display results -------------------------------------------
 
@@ -51,4 +53,3 @@ if ($reportok) {
     <tt>${output}</tt></p>
     </p>For more assistance, ask in the <a href='$help_url'>discussion topic</a> and include this identifier: ${upid}</p>";
 }
-

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -23,13 +23,11 @@ log_tool_access("pptext", $upid);
 // ----- user has option of uploading a Latin-1 file -------------------
 
 // main file
-if(ensure_utf8_file($target_name)) {
-    file_put_contents("$workdir/converted-main.txt", "text file converted from ISO-8859\n");
-}
+ensure_utf8_file($target_name);
 
 // good words file
-if ($gtarget_name && ensure_utf8_file($gtarget_name)) {
-    file_put_contents("$workdir/converted-gwf.txt", "good words file converted from ISO-8859\n");
+if ($gtarget_name) {
+    ensure_utf8_file($gtarget_name);
 }
 
 // ----- process user options ------------------------------------------
@@ -104,11 +102,12 @@ $command = join(" ", [
     "2>&1"
 ]);
 
-// echo $command;
-file_put_contents("$workdir/command.txt", $command);
+log_tool_action($workdir, "command", $command);
 
 // and finally, run pptext
 $output = shell_exec($command);
+
+log_tool_action($workdir, "output", $output);
 
 // ----- display results -------------------------------------------
 
@@ -133,4 +132,3 @@ if ($reportok) {
     <tt>${output}</tt></p>
     </p>For more assistance, ask in the <a href='$help_url'>discussion topic</a> and include this identifier: ${upid}</p>";
 }
-

--- a/pptext.php
+++ b/pptext.php
@@ -106,9 +106,6 @@ Left click to view or right click the link to download the results.</p>
 
 </form>
 MENU;
-$command = escapeshellcmd('bin/pptext -r');
-$output = shell_exec($command);
-echo "<div style='text-align:right; font-size:70%; color:white;'>pptext version: ".$output."</div>";
 }
 
 function get_js()


### PR DESCRIPTION
For each tool run, log information about the run into a single file in `$workdir`. Also output each command used and the command output. This simplifies debugging and troubleshooting.

This MR also removes outputting the `pptext` version on the input page (it's on the run output already) and ensures that the upload stops if the AV scanner fails to run correctly.

Testable in the [central-tool-logging](https://www.pgdp.org/~cpeel/ppwb.branch/central-tool-logging/) sandbox.