### PR TITLE
Show an optional alert message on each page

### DIFF
--- a/base.inc
+++ b/base.inc
@@ -40,6 +40,10 @@ $maint_ips = [];
 global $maint_days_ago;
 $maint_days_ago = 14;
 
+// If defined, $alert_message will be shown on all pages.
+global $alert_message;
+$alert_message = "";
+
 // Load an (optional) configuration file
 if(is_file("config.php")) {
     include("config.php");
@@ -57,6 +61,8 @@ function exception_handler($exception)
 // Output valid HTML page header
 function output_header($header="", $addl_links=[], $js="")
 {
+    global $alert_message;
+
     if($header)
     {
         $title = "PP Workbench: $header";
@@ -79,6 +85,7 @@ function output_header($header="", $addl_links=[], $js="")
     <script>$js</script>
   </head>
   <body>
+  <div class="alert">$alert_message</div>
   <div id="header" class='hsty'>$header</div>
 	<hr style='border:none; border-bottom:1px solid silver;'>  
 HEAD;

--- a/ppwb.css
+++ b/ppwb.css
@@ -12,6 +12,12 @@ body,html {
 	font-family: cutenotes;
 }
 
+.alert {
+	text-align: center;
+	color: red;
+	margin-bottom: 0.5em;
+}
+
 body {
 	min-width:500px;
 	max-width:700px;


### PR DESCRIPTION
Show an optional alert message. On TEST we will use this to redirect people to PROD after that goes live while still keeping a version on TEST for developing new features.

See it in the [alert-message](https://www.pgdp.org/~cpeel/ppwb.branch/alert-message/) sandbox.

I believe this is the last thing I want to get in before moving it to pgdp.net.