### PR TITLE
report parsing errors and exit

### DIFF
--- a/base.inc
+++ b/base.inc
@@ -300,3 +300,15 @@ function ensure_utf8_file($filename) {
     return false;
 }
 
+// from https://stackoverflow.com/questions/2320608/php-stderr-after-exec
+function run_command($cmd, &$stdout=null, &$stderr=null) {
+    $proc = proc_open($cmd, [
+        1 => ['pipe','w'],
+        2 => ['pipe','w'],
+    ], $pipes);
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+    return proc_close($proc);
+}

--- a/bin/comp_pp.py
+++ b/bin/comp_pp.py
@@ -219,8 +219,11 @@ class SourceFile(object):
                                       if parser.error_log[0].type != 513]
 
         if len(self.parser_errlog):
-            raise SyntaxError("Parsing errors in document: " +
-                              os.path.basename(name))
+            errors = []
+            for entry in parser.error_log:
+                errors.append(f"{entry.type_name} near line {entry.line}: {entry.message}")
+            raise SyntaxError(f"Parsing errors in document {os.path.basename(name)}: \n"
+                + "\n".join(errors))
 
         self.tree = tree.getroottree()
         self.text = text.splitlines()
@@ -1610,12 +1613,15 @@ def main():
     args = parser.parse_args()
 
     x = CompPP(args)
-    if args.simple_html:
-        x.simple_html()
-    else:
-        _, html_content, fn1, fn2 = x.do_process()
-
-        output_html(args, html_content, fn1, fn2)
+    try:
+        if args.simple_html:
+            x.simple_html()
+        else:
+            _, html_content, fn1, fn2 = x.do_process()
+            output_html(args, html_content, fn1, fn2)
+    except SyntaxError as exception:
+        print(exception)
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -57,18 +57,13 @@ $scommand = join(" ", [
     escapeshellarg($target_name2)
 ]);
 
-$command = join(" ", [
-    escapeshellcmd($scommand),
-    " > ",
-    escapeshellarg("$workdir/result.html"),
-    "2>&1"
-]);
+$command = escapeshellcmd($scommand);
 
 log_tool_action($workdir, "command", $command);
 
-$output = shell_exec($command);
+$exit_code = run_command($command, $output, $error);
 
-log_tool_action($workdir, "output", $output);
+log_tool_action($workdir, "error", $error);
 
 // ----- display results -------------------------------------------
 
@@ -77,9 +72,10 @@ output_header("ppcomp Results");
 $reportok = false;
 
 echo "<p>";
-if (file_exists("$workdir/result.html")) {
-   echo "results available: <a href='$workurl/result.html'>here</a>.<br/>";
-   $reportok = true;
+if($exit_code == 0) {
+    file_put_contents("$workdir/result.html", $output);
+    echo "results available: <a href='$workurl/result.html'>here</a>.<br/>";
+    $reportok = true;
 }
 if ($reportok) {
     echo "Left click to view. Right click to download.</p>";

--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -84,6 +84,7 @@ if (file_exists("$workdir/result.html")) {
 if ($reportok) {
     echo "Left click to view. Right click to download.</p>";
 } else {
+    $output = nl2br($output);
     echo "<p>Whoops! Something went wrong and no output was generated.
     The error message was<br/><br/>
     <tt>${output}</tt></p>


### PR DESCRIPTION
I didn't write comp_pp.py, nor could I have written it. But there is an open issue "ppcomp fails to parse html file" and I've put together code to close it out. I'm guessing if the comp_pp.py author had made this patch it would be more elegant. What I do is report anything that can't be parsed and which previously caused the program to error out. I report it and then exit cleanly. It now looks like this:

comp_pp parsing error report:
ERR_TAG_NAME_MISMATCH near line 68: Unexpected end tag : hr
ERR_TAG_NAME_MISMATCH near line 91: Unexpected end tag : hr
exiting

My source file had `<hr></hr>` on lines 68 and 91 to cause this report. As I said, I'm a out of my league with lxml and this code, so if anyone has a better way, please fix it: you can't hurt my feelings. Otherwise, here is my pull request.
