### PR TITLE
Remove file size check

### DIFF
--- a/base.inc
+++ b/base.inc
@@ -265,11 +265,6 @@ function process_file_upload($formid, $workdir, $allowed_extensions=[])
                 sprintf("file must have a %s extension", join(" or ", $allowed_extensions))
             );
         }
-
-        // is it small enough?
-        if ($file_size > 31457280) {
-            throw new UploadError("file size must be less than 30 MB");
-        }
     } catch(Exception $e) {
         unlink($final_filepath);
         rmdir($workdir);

--- a/index.php
+++ b/index.php
@@ -6,6 +6,7 @@ output_content();
 
 function output_content()
 {
+    $max_upload_size = ini_get("upload_max_filesize");
     global $docs_url, $help_url;
 echo <<<MENU
 <p>Welcome to the Post-Processing Workbench. Post Processors usually generate
@@ -26,8 +27,7 @@ files. Follow these links for details and to access the programs:</p>
     <li><a href='./ppcomp.php'>ppcomp</a> to compare two files, text or HTML mixed</li>
 </ul>
 
-<p>
-
+<p><i>The maximum upload size for this system is $max_upload_size.</i></p>
 
 <p>Please remember to also run these tests:</p>
   <ul style='margin-top:0'>


### PR DESCRIPTION
If the file is small enough to be successfully uploaded (based on PHP configuration values) it should be small enough to run the tools against.

For TEST the max upload size is 48MB. For PROD it is 64MB.