### PR TITLE
Make ppcomp cope with HTML5

### DIFF
--- a/bin/comp_pp.py
+++ b/bin/comp_pp.py
@@ -139,6 +139,8 @@ class SourceFile(object):
             parser = etree.XMLParser(dtd_validation=True)
         if any(["DTD HTML" in x for x in header]):
             parser = etree.HTMLParser()
+        if any(["DOCTYPE html" in x for x in header]):
+            parser = etree.HTMLParser()
 
         if parser is None:
             raise SyntaxError("No parser found for that type of document: " +


### PR DESCRIPTION
Previously ppcomp was reporting that no parser was found when trying to
compare an HTML5 file with text file.

If the HTML5 header is found, use the HTMLParser.