### PR TITLE
Don't double-escape shell commands

### DIFF
--- a/base.inc
+++ b/base.inc
@@ -224,7 +224,7 @@ function process_file_upload($formid, $workdir, $allowed_extensions=[])
         // does it pass the anti-virus tests?
         $av_test_result = array();
         $av_retval = 0;
-        $cmd = "/usr/bin/clamdscan '" . escapeshellcmd($final_filepath) . "'";
+        $cmd = "/usr/bin/clamdscan " . escapeshellarg($final_filepath);
         exec($cmd, $av_test_result, $av_retval);
         if ($av_retval == 1) {
             throw new UploadError("file rejected by AV scanner");
@@ -266,7 +266,7 @@ function ensure_utf8_file($filename) {
         $cmd = sprintf("iconv -f ISO_8859-1 -t UTF-8 -o %s %s",
             escapeshellarg($tmpfname), escapeshellarg($filename)
         );
-        exec(escapeshellcmd($cmd), $ppf_output, $ppf_exitcode);
+        exec($cmd, $ppf_output, $ppf_exitcode);
         rename($tmpfname, $filename);
         log_tool_action(dirname($filename), "UTF-8 conversion", "$filename converted from ISO-8859-1");
         return true;

--- a/maint.php
+++ b/maint.php
@@ -25,12 +25,11 @@ foreach(new DirectoryIterator($base_workdir) as $dir) {
     if($dir->getMTime() < $maint_cutoff) {
         echo "Deleting " . $dir->getFilename() . "\n";
 
-        $scommand = join(" ", [
+        $command = join(" ", [
             "rm",
             "-rf",
             escapeshellarg("$base_workdir/" . $dir->getFilename())
         ]);
-        $command = escapeshellcmd($scommand);
 
         // echo "$command\n";
         shell_exec($command);

--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -50,15 +50,13 @@ log_tool_access("ppcomp", $upid);
 
 // ----- run the ppcomp command ----------------------------------------
 
-$scommand = join(" ", [
+$command = join(" ", [
     $python_runner,
     "./bin/ppcomp/ppcomp/ppcomp.py",
     join(" ", $options),
     escapeshellarg($target_name1),
     escapeshellarg($target_name2)
 ]);
-
-$command = escapeshellcmd($scommand);
 
 log_tool_action($workdir, "command", $command);
 

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -55,17 +55,13 @@ if(isset($_POST['ver']) && $_POST['ver'] == 'Yes') {
 // ----- run the pphtml command ----------------------------------------
 
 // build the command
-$scommand = join(" ", [
+$command = join(" ", [
     $python_runner,
     "./bin/pphtml/pphtml.py",
     join(" ", $options),
     "-i " . escapeshellarg($user_htmlfile),
-    "-o " . escapeshellarg("$workdir/report.html")
-]);
-
-$command = join(" ", [
-    escapeshellcmd($scommand),
-    "2>&1"
+    "-o " . escapeshellarg("$workdir/report.html"),
+    "2>&1",
 ]);
 
 log_tool_action($workdir, "command", $command);

--- a/ppsmq-action.php
+++ b/ppsmq-action.php
@@ -15,16 +15,12 @@ log_tool_access("ppsmq", $upid);
 // ----- run the ppsmq command ----------------------------------------
 
 // build the command
-$scommand = join(" ", [
+$command = join(" ", [
     $python_runner,
     "./bin/ppsmq.py",
     "-i " . escapeshellarg($target_name),
-    "-o " . escapeshellarg("$workdir/report.txt")
-]);
-
-$command = join(" ", [
-    escapeshellcmd($scommand),
-    "2>&1"
+    "-o " . escapeshellarg("$workdir/report.txt"),
+    "2>&1",
 ]);
 
 log_tool_action($workdir, "command", $command);

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -90,17 +90,13 @@ if ($gtarget_name) {
 // ----- run the pptext command ----------------------------------------
 
 // build the command
-$scommand = join(" ", [
+$command = join(" ", [
     "nice",
     "./bin/pptext/pptext",
     join(" ", $options),
     "-i " . escapeshellarg($target_name),
-    "-o " . escapeshellarg($workdir)
-]);
-
-$command = join(" ", [
-    escapeshellcmd($scommand),
-    "2>&1"
+    "-o " . escapeshellarg($workdir),
+    "2>&1",
 ]);
 
 log_tool_action($workdir, "command", $command);


### PR DESCRIPTION
Using `escapeshellarg()` to escape user inputs being passed as args is all that is necessary before running a command. `escapeshellcmd()` can double encode unmatched double- and single-quotes when used with `escapeshellarg()`.

https://gist.github.com/Zenexer/40d02da5e07f151adeaeeaa11af9ab36 is an interesting read.

Testable at https://www.pgdp.org/~cpeel/ppwb