### PR TITLE
Update HTML to make it pass validation

### DIFF
--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -73,7 +73,7 @@ $reportok = false;
 echo "<p>";
 if($exit_code == 0) {
     file_put_contents("$workdir/result.html", $output);
-    echo "results available: <a href='$workurl/result.html'>here</a>.<br/>";
+    echo "results available: <a href='$workurl/result.html'>here</a>.<br>";
     $reportok = true;
 }
 if ($reportok) {
@@ -81,7 +81,7 @@ if ($reportok) {
 } else {
     $output = nl2br($output);
     echo "<p>Whoops! Something went wrong and no output was generated.
-    The error message was<br/><br/>
+    The error message was<br><br>
     <tt>${output}</tt></p>
     </p>For more assistance, ask in the <a href='$help_url'>discussion topic</a> and include this identifier: ${upid}</p>";
 }

--- a/ppcomp.php
+++ b/ppcomp.php
@@ -20,79 +20,79 @@ or views the results file.</p>
 
 <div>General options</div>
 
-<input type="checkbox" name="ignore-case" value="No" id="ignore-case" autocomplete="off">
-<label for="ignore-case">Ignore case when comparing</label><br/>
+<input type="checkbox" name="ignore-case" value="No" id="ignore-case">
+<label for="ignore-case">Ignore case when comparing</label><br>
 
-<input type="checkbox" name="extract-footnotes" value="No" id="extract-footnotes" autocomplete="off">
-<label for="extract-footnotes">Extract and process footnotes separately</label><br/>
-<br />
+<input type="checkbox" name="extract-footnotes" value="No" id="extract-footnotes">
+<label for="extract-footnotes">Extract and process footnotes separately</label><br>
+<br>
 
 <div>Options for transforming an HTML file:</div>
 
-<input type="checkbox" name="css-add-illustration" value="No" id="css-add-illustration" autocomplete="off">
-<label for="css-add-illustration">add [Illustration ] tag</label><br/>
+<input type="checkbox" name="css-add-illustration" value="No" id="css-add-illustration">
+<label for="css-add-illustration">add [Illustration ] tag</label><br>
 
-<input type="checkbox" name="css-add-sidenote" value="No" id="css-add-sidenote" autocomplete="off">
-<label for="css-add-sidenote">add [Sidenote: ...]</label><br/>
+<input type="checkbox" name="css-add-sidenote" value="No" id="css-add-sidenote">
+<label for="css-add-sidenote">add [Sidenote: ...]</label><br>
 
-<input type="checkbox" name="css-greek-title-plus" value="No" id="css-greek-title-plus" autocomplete="off">
-<label for="css-greek-title-plus">use greek transliteration in title attribute</label><br/>
+<input type="checkbox" name="css-greek-title-plus" value="No" id="css-greek-title-plus">
+<label for="css-greek-title-plus">use greek transliteration in title attribute</label><br>
 
-<input type="checkbox" name="suppress-nbsp-num" value="No" id="suppress-nbsp-num" autocomplete="off">
-<label for="suppress-nbsp-num">Suppress non-breakable spaces between numbers</label><br/>
+<input type="checkbox" name="suppress-nbsp-num" value="No" id="suppress-nbsp-num">
+<label for="suppress-nbsp-num">Suppress non-breakable spaces between numbers</label><br>
 
-<input type="checkbox" name="ignore-0-space" value="No" id="ignore-0-space" autocomplete="off">
-<label for="ignore-0-space">suppress zero width space (U+200b)</label><br/>
+<input type="checkbox" name="ignore-0-space" value="No" id="ignore-0-space">
+<label for="ignore-0-space">suppress zero width space (U+200b)</label><br>
 
 <!--
-<input type="checkbox" name="bold-replace" value="No" id="bold-replace" autocomplete="off">
-<label for="bold-replace">replace &lt;b>&lt;/b> markup with "="</label><br/>
-<br />
+<input type="checkbox" name="bold-replace" value="No" id="bold-replace">
+<label for="bold-replace">replace &lt;b>&lt;/b> markup with "="</label><br>
+<br>
 -->
 
 <div>Options for transforming a text file:</div>
 
-<input type="checkbox" name="suppress-footnote-tags" value="No" id="suppress-footnote-tags" autocomplete="off">
-<label for="suppress-footnote-tags">Suppress "[Footnote ?:" marks</label><br/>
+<input type="checkbox" name="suppress-footnote-tags" value="No" id="suppress-footnote-tags">
+<label for="suppress-footnote-tags">Suppress "[Footnote ?:" marks</label><br>
 
-<input type="checkbox" name="suppress-illustration-tags" value="No" id="suppress-illustration-tags" autocomplete="off">
-<label for="suppress-illustration-tags">Suppress "[Illustration:" marks</label><br/>
-<br />
+<input type="checkbox" name="suppress-illustration-tags" value="No" id="suppress-illustration-tags">
+<label for="suppress-illustration-tags">Suppress "[Illustration:" marks</label><br>
+<br>
 
 <div>If comparing with a file from the rounds</div>
 
-<input type="checkbox" name="suppress-proofers-notes" value="No" id="suppress-proofers-notes" autocomplete="off">
+<input type="checkbox" name="suppress-proofers-notes" value="No" id="suppress-proofers-notes">
 <label for="suppress-proofers-notes">In Px/Fx versions, remove [**proofreaders notes]</label>
-<br/>
+<br>
 
-<input type="checkbox" name="regroup-split-words" value="No" id="regroup-split-words" autocomplete="off">
-<label for="regroup-split-words">In Px/Fx versions, regroup split wo-* *rds</label><br />
+<input type="checkbox" name="regroup-split-words" value="No" id="regroup-split-words">
+<label for="regroup-split-words">In Px/Fx versions, regroup split wo-* *rds</label><br>
 
-<input type="checkbox" name="ignore-format" value="No" id="ignore-format" autocomplete="off">
-<label for="ignore-format">Silence formating differences</label><br/>
+<input type="checkbox" name="ignore-format" value="No" id="ignore-format">
+<label for="ignore-format">Silence formating differences</label><br>
 
 <div style='margin-left:0.2em'>Type of text cleaning:
 &nbsp;&nbsp;&nbsp;
-<input type="radio" name="txt-cleanup-type" value="b" checked="Yes" /> best effort
+<input type="radio" name="txt-cleanup-type" value="b" checked> best effort
 &nbsp;&nbsp;
-<input type="radio" name="txt-cleanup-type" value="n" /> none
+<input type="radio" name="txt-cleanup-type" value="n"> none
 &nbsp;&nbsp;
-<input type="radio" name="txt-cleanup-type" value="p" /> proofers
+<input type="radio" name="txt-cleanup-type" value="p"> proofers
 </div>
-<br />
+<br>
 
-<br />
+<br>
 <table>
 <tr>
     <td style='text-align:right'><label for='userfile1'>file1:</label></td>
-    <td><input type="file" name="userfile1" autocomplete=off /></td>
+    <td><input type="file" name="userfile1" id="userfile1"></td>
 </tr>
 <tr>
     <td style='text-align:right'><label for='userfile2'>file2:</label></td>
-    <td><input type="file" name="userfile2" autocomplete=off /></td>
+    <td><input type="file" name="userfile2" id="userfile2"></td>
 </tr>
 </table>
-<div style='margin-top:1em; margin-bottom:0em;'><input type="submit" value="Submit" name="upload"/></div>
+<div style='margin-top:1em; margin-bottom:0em;'><input type="submit" value="Submit" name="upload"></div>
 </form>
 
 

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -79,14 +79,14 @@ $reportok = false;
 
 echo "<p>";
 if (file_exists("$workdir/report.html")) {
-   echo "results available: <a href='$workurl/report.html'>here</a>.<br/>";
+   echo "results available: <a href='$workurl/report.html'>here</a>.<br>";
    $reportok = true;
 }
 if ($reportok) {
     echo "Left click to view. Right click to download.</p>";
 } else {
     echo "<p>Whoops! Something went wrong and no output was generated.
-    The error message was<br/><br/>
+    The error message was<br><br>
     <tt>${output}</tt></p>
     </p>For more assistance, ask in the <a href='$help_url'>discussion topic</a> and include this identifier: ${upid}</p>";
 }

--- a/pphtml.php
+++ b/pphtml.php
@@ -25,16 +25,16 @@ test will report these as [FAIL] duplicate targets.</p>
 
 <form target="_blank" action="pphtml-action.php" method="POST" enctype="multipart/form-data">
 
-<input type="checkbox" name="ver" value="Yes" id="ver" autocomplete="off">
-<label for="ver">verbose operation</label><br/>
+<input type="checkbox" name="ver" value="Yes" id="ver">
+<label for="ver">verbose operation</label><br>
 
 <table>
 <tr>
     <td style='text-align:right'><label for='userfile'>User zip file (HTML+images)</label></td>
-    <td><input type="file" name="userfile" autocomplete=off /></td>
+    <td><input type="file" name="userfile" id="userfile"></td>
 </tr>
 </table>
-<div style='margin-top:1em; margin-bottom:0em;'><input type="submit" value="Submit" name="upload"/></div>
+<div style='margin-top:1em; margin-bottom:0em;'><input type="submit" value="Submit" name="upload"></div>
 </form>
 
 MENU;

--- a/ppsmq-action.php
+++ b/ppsmq-action.php
@@ -38,14 +38,14 @@ $reportok = false;
 
 echo "<p>";
 if (file_exists("$workdir/report.txt")) {
-   echo "results available: <a href='$workurl/report.txt'>here</a>.<br/>";
+   echo "results available: <a href='$workurl/report.txt'>here</a>.<br>";
    $reportok = true;
 }
 if ($reportok) {
     echo "Left click to view. Right click to download.</p>";
 } else {
     echo "<p>Whoops! Something went wrong and no output was generated.
-    The error message was<br/><br/>
+    The error message was<br><br>
     <tt>${output}</tt></p>
     </p>For more assistance, ask in the <a href='$help_url'>discussion topic</a> and include this identifier: ${upid}</p>";
 }

--- a/ppsmq.php
+++ b/ppsmq.php
@@ -41,10 +41,10 @@ echo <<<MENU
 <table>
   <tr>
           <td style='text-align:right'><label for='userfile'>User text file </label></td>
-          <td><input type="file" name="userfile" autocomplete=off /></td>
+          <td><input type="file" name="userfile" id="userfile"></td>
   </tr>
 </table>
-<div style='margin-top:1em; margin-bottom:0em;'><input type="submit" value="Submit" name="upload"/></div>
+<div style='margin-top:1em; margin-bottom:0em;'><input type="submit" value="Submit" name="upload"></div>
 </form>
 
 MENU;

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -114,18 +114,18 @@ $reportok = false;
 
 echo "<p>";
 if (file_exists("$workdir/report.html")) {
-   echo "results available: <a href='$workurl/report.html'>here</a>.<br/>";
+   echo "results available: <a href='$workurl/report.html'>here</a>.<br>";
    $reportok = true;
 }
 if (file_exists("$workdir/scanreport.txt")) {
-   echo "punctuation scan report: <a href='$workurl/scanreport.txt'>here</a>.<br/>";
+   echo "punctuation scan report: <a href='$workurl/scanreport.txt'>here</a>.<br>";
    $reportok = true;
 }
 if ($reportok) {
     echo "Left click to view. Right click to download.</p>";
 } else {
     echo "<p>Whoops! Something went wrong and no output was generated.
-    The error message was<br/><br/>
+    The error message was<br><br>
     <tt>${output}</tt></p>
     </p>For more assistance, ask in the <a href='$help_url'>discussion topic</a> and include this identifier: ${upid}</p>";
 }

--- a/pptext.php
+++ b/pptext.php
@@ -41,7 +41,7 @@ function output_content()
         $dictionary_html .= "<tr>";
         foreach($language as $code => $locale_name) {
             $checked = ($code == "en") ? "checked" : "";
-            $dictionary_html .= "<td align='right' style='padding-left:30px'>$locale_name: <input type='checkbox' name='wlangs[]' value='$code' autocomplete='off' $checked/></td>";
+            $dictionary_html .= "<td align='right' style='padding-left:30px'>$locale_name: <input type='checkbox' name='wlangs[]' value='$code' $checked></td>";
         }
         $dictionary_html .= "</tr>";
     }
@@ -81,54 +81,55 @@ Left click to view or right click the link to download the results.</p>
     <table>
       <tr>
           <td style='text-align:right'><label for='userfile'>User text file </label></td>
-          <td><input type="file" name="userfile" autocomplete=off /></td>
+          <td><input type="file" name="userfile" id="userfile"></td>
       </tr>
-      </tr>
+      <tr>
           <td style='text-align:right'><label for='goodfile'>Good words file (optional)</label></td>
-          <td><input type="file" name="goodfile" autocomplete=off /></td>
+          <td><input type="file" name="goodfile" id="goodfile"></td>
       </tr>
     </table>
 
-    <div>Select wordlist language(s)<br />
+    <div>Select wordlist language(s)<br>
       <table style='margin-left: 50px;'>
       $dictionary_html
       </table>
     </div>
 
-    <br/>
+    <br>
 
-<div>Select/unselect Tests<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name='rat" value="Yes" id='rat' autocomplete="off" class="chk_boxes">
-    <label for="rat">run all tests</label><br/>
+    <div>Select/unselect Tests<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rat" value="Yes" id='rat' class="chk_boxes">
+    <label for="rat">run all tests</label><br>
 
-    <hr style='border:none; border-bottom:1px solid silver; width:10%; float:left; margin-left:24px;' /><br />
+    <hr style='border:none; border-bottom:1px solid silver; width:10%; float:left; margin-left:24px;'><br>
 
-    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rspl" value="Yes" id="rspl" autocomplete="off" class="chk_boxes1">
-    <label for="rspl">run spellcheck</label><br/>    
+    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rspl" value="Yes" id="rspl" class="chk_boxes1">
+    <label for="rspl">run spellcheck</label><br>
 
-    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="redi" value="Yes" id="redi" autocomplete="off" class="chk_boxes1">
-    <label for="redi">run edit distance check</label><br/>
+    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="redi" value="Yes" id="redi" class="chk_boxes1">
+    <label for="redi">run edit distance check</label><br>
 
-    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rtxt" value="Yes" id="rtxt" autocomplete="off" class="tchk chk_boxes1 chk_t">
-    <label for="rtxt">run text checks</label><br/>
+    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rtxt" value="Yes" id="rtxt" class="tchk chk_boxes1 chk_t">
+    <label for="rtxt">run text checks</label><br>
 
-    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rthc" value="Yes" id="rthc" autocomplete="off" class="tchks chk_boxes1 chk_t1">
-    <label for="rthc">&nbsp;&nbsp;&nbsp;&nbsp;run hyphen consistency</label><br/>
+    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rthc" value="Yes" id="rthc" class="tchks chk_boxes1 chk_t1">
+    <label for="rthc">&nbsp;&nbsp;&nbsp;&nbsp;run hyphen consistency</label><br>
 
-    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rhsc" value="Yes" id="rhsc" autocomplete="off" class="tchks chk_boxes1 chk_t1">
-    <label for="rhsc">&nbsp;&nbsp;&nbsp;&nbsp;run hyphen-space consistency</label><br/>
+    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rhsc" value="Yes" id="rhsc" class="tchks chk_boxes1 chk_t1">
+    <label for="rhsc">&nbsp;&nbsp;&nbsp;&nbsp;run hyphen-space consistency</label><br>
 
-    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rjee" value="Yes" id="rjee" autocomplete="off" class="chk_boxes1">
-    <label for="sqc">run jeebies check</label><br/>
+    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rjee" value="Yes" id="rjee" class="chk_boxes1">
+    <label for="rjee">run jeebies check</label><br>
 
-    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rsqc" value="Yes" id="rsqc" autocomplete="off" class="chk_boxes1">
-    <label for="rsqc">run smart quote check</label><br/>
+    &nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="rsqc" value="Yes" id="rsqc" class="chk_boxes1">
+    <label for="rsqc">run smart quote check</label><br>
+    </div>
 
-    <br/>
-    <input type="checkbox" name="ver" value="Yes" id="ver" autocomplete="off">
-    <label for="ver">verbose operation</label><br/>
+    <br>
+    <input type="checkbox" name="ver" value="Yes" id="ver">
+    <label for="ver">verbose operation</label><br>
 
-    <div style='margin-top:1em; margin-bottom:0em;'><input type="submit" value="Submit" name="upload"/></div>
+    <div style='margin-top:1em; margin-bottom:0em;'><input type="submit" value="Submit" name="upload"></div>
 
 </form>
 MENU;


### PR DESCRIPTION
Update the HTML to make it pass the W3 Validator. Mostly this was removing `autocomplete="off"` from inputs that did not support it and updating inputs to have an ID so that `<label for='xx'>` was pointing at a valid thing but there were some legit errors in `pptext.php` that were fixed.

Also update the tags to make it HTML, not XHTML, as that's what doctype we're providing.

No functional changes.

This is testable in https://www.pgdp.org/~cpeel/ppwb/index.php