### PR TITLE
Use absolute paths & allow configurable AV path

### DIFF
--- a/base.inc
+++ b/base.inc
@@ -29,6 +29,10 @@ $base_workurl = "./t";
 global $python_runner;
 $python_runner = "python3";
 
+// If set, uploads will be run through the following anti-virus scanner
+global $av_scanner;
+$av_scanner = "";
+
 // URLs for help and documentation links.
 global $help_url, $docs_url;
 $help_url = "https://www.pgdp.net/phpBB3/viewtopic.php?f=13&t=64838";
@@ -196,6 +200,8 @@ class UploadError extends Exception {}
 
 function process_file_upload($formid, $workdir, $allowed_extensions=[])
 {
+    global $av_scanner;
+
     if(!isset($_FILES[$formid]) || !$_FILES[$formid]["name"]) {
         throw new UploadError("No file was uploaded");
     }
@@ -226,15 +232,17 @@ function process_file_upload($formid, $workdir, $allowed_extensions=[])
     // begin a series of validation tests
     try {
         // does it pass the anti-virus tests?
-        $av_test_result = array();
-        $av_retval = 0;
-        $cmd = "/usr/bin/clamdscan " . escapeshellarg($final_filepath);
-        exec($cmd, $av_test_result, $av_retval);
-        if ($av_retval == 1) {
-            throw new UploadError("file rejected by AV scanner");
-        }
-        if ($av_retval != 0) {
-            throw new UploadError("error running AV scanner");
+        if (file_exists($av_scanner)) {
+            $av_test_result = array();
+            $av_retval = 0;
+            $cmd = "$av_scanner " . escapeshellarg($final_filepath);
+            exec($cmd, $av_test_result, $av_retval);
+            if ($av_retval == 1) {
+                throw new UploadError("file rejected by AV scanner");
+            }
+            if ($av_retval != 0) {
+                throw new UploadError("error running AV scanner");
+            }
         }
 
         // was a file uploaded?

--- a/base.inc
+++ b/base.inc
@@ -11,6 +11,10 @@ set_exception_handler('exception_handler');
 // Define some global configuration values. These can be overridden in
 // an optional configuration file (config.php).
 
+// Determine the repo base for using the external tools
+global $base_codedir;
+$base_codedir = dirname($_SERVER['SCRIPT_FILENAME']);
+
 // $base_workdir is where files are uploaded and where results are stored.
 // It must be writeable by the webserver and also needs to be accessible by
 // URL ($base_workurl). $base_workurl can be a relative or absolute URL to

--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -57,7 +57,7 @@ log_tool_access("ppcomp", $upid);
 
 $command = join(" ", [
     $python_runner,
-    "./bin/ppcomp/ppcomp/ppcomp.py",
+    "$base_codedir/bin/ppcomp/ppcomp/ppcomp.py",
     join(" ", $options),
     escapeshellarg($target_name1),
     escapeshellarg($target_name2)

--- a/pphtml-action.php
+++ b/pphtml-action.php
@@ -57,7 +57,7 @@ if(isset($_POST['ver']) && $_POST['ver'] == 'Yes') {
 // build the command
 $command = join(" ", [
     $python_runner,
-    "./bin/pphtml/pphtml.py",
+    "$base_codedir/bin/pphtml/pphtml.py",
     join(" ", $options),
     "-i " . escapeshellarg($user_htmlfile),
     "-o " . escapeshellarg("$workdir/report.html"),

--- a/ppsmq-action.php
+++ b/ppsmq-action.php
@@ -17,7 +17,7 @@ log_tool_access("ppsmq", $upid);
 // build the command
 $command = join(" ", [
     $python_runner,
-    "./bin/ppsmq.py",
+    "$base_codedir/bin/ppsmq.py",
     "-i " . escapeshellarg($target_name),
     "-o " . escapeshellarg("$workdir/report.txt"),
     "2>&1",

--- a/pptext-action.php
+++ b/pptext-action.php
@@ -92,7 +92,7 @@ if ($gtarget_name) {
 // build the command
 $command = join(" ", [
     "nice",
-    "./bin/pptext/pptext",
+    "$base_codedir/bin/pptext/pptext",
     join(" ", $options),
     "-i " . escapeshellarg($target_name),
     "-o " . escapeshellarg($workdir),


### PR DESCRIPTION
When troubleshooting the pptext problem earlier (fixed in https://github.com/DistributedProofreaders/pptext/pull/12) I was evaluating if relative paths were the problem in ppwb. It wasn't, but using absolute paths is a best practice and since I solved it...

This includes an update to make the AV scanner path configurable since we use `clamscan` on TEST and `clamdscan` on PROD.

Testable in https://www.pgdp.org/~cpeel/ppwb/