### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM php:8.2.29-apache
+
+# Did not find the aspell packages for Afrikaans, Latin
+RUN apt-get update \
+    && apt-get install -y \
+        dwdiff python3-full golang libzip-dev aspell \
+        aspell-en aspell-da aspell-nl aspell-eo aspell-fr \
+        aspell-de aspell-el aspell-it aspell-pt aspell-ro \
+        aspell-es aspell-gl-minimos \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN mkdir /venv \
+    && python3 -m venv /venv \
+    && /venv/bin/pip3 install \
+        tinycss cssselect lxml html5lib pytest Pillow regex
+RUN pecl install zip \
+    && echo "extension=zip" >> $PHP_INI_DIR/php.ini-development \
+    && mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
+
+COPY docker-entrypoint.sh /
+RUN chmod 755 /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# this CMD is in the upstream image but it gets lost somehow; redefine it
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -45,3 +45,36 @@ $python_runner = "env VIRTUAL_ENV=/path/to/venv PATH=/path/to/venv/bin/python3";
 Ensure that the web server can access the virtualenv. virtualenvs created
 in `~/.local` may need to have the permissions updated (o+x) to allow the
 web server sufficient permissions.
+
+## Using Docker for development / testing
+
+For convenience, you can run ppwb, ppcomp, pphtml, and pptext in a container.
+The included Docker Compose configuration will run a PPWB instance on localhost,
+using the code on your computer (outside the container) mounted into the
+container.
+
+See the above instructions about installing ppcomp, pptext, pphtml under the
+"bin" directory. Depending what you're working on, you can clone the repository
+URLs above, or substitute your own forked URLs.
+
+Once they're in place, build the image:
+
+    docker compose build
+
+And then bring up the service:
+
+    # add -d if you prefer to run in the background
+    docker compose up
+
+Visit http://localhost:8080 in your browser. (The port can be changed by editing
+docker-compose.yml, if necessary.)
+
+### When changes take effect in Docker
+
+Changes in pphtml and ppcomp should go live as soon as you save the file.
+
+Changing code from the ppwb project itself will require a rebuild of the image
+(and a restart of the service). This includes ppsmq.
+
+Changing the Go code for pptext will take effect with a restart of the service
+(no rebuild of Docker required). The startup sequence rebuilds pptext.

--- a/README.md
+++ b/README.md
@@ -69,12 +69,16 @@ And then bring up the service:
 Visit http://localhost:8080 in your browser. (The port can be changed by editing
 docker-compose.yml, if necessary.)
 
-### When changes take effect in Docker
+### When changes take effect
 
-Changes in pphtml and ppcomp should go live as soon as you save the file.
+To change pptext Go code, you'll need to restart services.
+(The startup script rebuilds pptext.)
 
-Changing code from the ppwb project itself will require a rebuild of the image
-(and a restart of the service). This includes ppsmq.
+    docker compose restart
 
-Changing the Go code for pptext will take effect with a restart of the service
-(no rebuild of Docker required). The startup sequence rebuilds pptext.
+If you make changes to `Dockerfile` or `docker-entrypoint.sh`, rebuild the
+image and restart.
+
+To change the port of the web server, update `docker-compose.yml` and restart.
+
+All other changes should take effect as soon as you save the file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  ppwb:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    image: ppwb
+    ports:
+      - 8080:80
+    volumes:
+      - .:/var/www/html

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Create working directory
+mkdir -p /var/www/html/t
+
+# Rebuild pptext binary
+cd /var/www/html/bin/pptext
+go build pptext.go
+
+# Configure path to Python venv
+echo '<?php $python_runner = "/venv/bin/python3"; ?>' > /var/www/html/config.php
+
+# Call the original entrypoint (plus CMD)
+cd
+exec docker-php-entrypoint $@


### PR DESCRIPTION
This PR adds a `docker compose` setup allowing for easily running ppwb and its child tools anywhere without installing additional tools or server components.