### PR TITLE
Add support for ppcomp 'suppress-sidenote-tags'

### DIFF
--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -21,6 +21,7 @@ $available_boolean_options = [
     'ignore-format',
     'suppress-footnote-tags',
     'suppress-illustration-tags',
+    'suppress-sidenote-tags',
     'ignore-case',
     'extract-footnotes',
     'ignore-0-space',

--- a/ppcomp.php
+++ b/ppcomp.php
@@ -63,6 +63,9 @@ or views the results file.</p>
 
 <input type="checkbox" name="suppress-illustration-tags" value="No" id="suppress-illustration-tags">
 <label for="suppress-illustration-tags">Suppress "[Illustration:" marks</label><br>
+
+<input type="checkbox" name="suppress-sidenote-tags" value="No" id="suppress-sidenote-tags">
+<label for="suppress-sidenote-tags">Suppress "[Sidenote:" marks</label><br>
 <br>
 
 <div>If comparing with a file from the rounds</div>


### PR DESCRIPTION
PPWB already supports the `--css-add-sidenote` feature of ppcomp, which adds `[Sidenote: ]` tags to the HTML file where the `.sidenote` class is applied.

This PR adds support for the other case (`--suppress-sidenote-tags`): removing `[Sidenote: ]` from the text file. This can be useful because the `.sidenote` class may not be the way the PPer implemented sidenotes in their project. DPwiki even outlines suggested methods for inline sidenote markup using `.sni`, in which case the `.sidenote` class would not appear and ppcomp would not do the right thing.

(No change to ppcomp is needed for this to work; it's already supported.)

This is part of my larger effort to port certain things from PPtools to PPWB, to ease transition of PPtools users onto PPWB. PPtools hasn't had proper attention for some time; in particular it has no HTML5 support (aside from ppcomp). I hope to port certain features to PPWB and eventually shut the PPTools service down. It has become far less useful without HTML5 support, but there are still people using it. Further PRs will likely follow this one.

**Testing notes:**

Take the text and HTML versions of a book and add at least two sidenotes.

In the text file, wrap them in `[Sidenote: ]` tags.

In the HTML file, wrap them in `<div class="xxxxxx"> </div>` tags. Use the `sidenote` class for one, and anything you like for the other(s) [`sni`, `snoopy`, `mycustomsidenoteclass`, whatever].

Compare the two files using ppwb/ppcomp.

Comparing with no options checked: you should get a diff because one file has the `[Sidenote:` tags but the other doesn't.

Comparing with `Add [Sidenote: ...]` checked for HTML: you should get no diff for the sidenote where you used the class name `sidenote`, but you should get a diff for the other. That's because the `css-add-sidenote` feature only works with that specific class name.

Comparing with `Suppress "[Sidenote:" marks` checked for text: you should get no diff related to the sidenotes at all, assuming the text content of the sidenotes is the same.
