### PR TITLE
Bind 8080 to localhost only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,6 @@ services:
       dockerfile: ./Dockerfile
     image: ppwb
     ports:
-      - 8080:80
+      - 127.0.0.1:8080:80
     volumes:
       - .:/var/www/html


### PR DESCRIPTION
Rather than bind port 8080 in the Docker setup to 0.0.0.0, bind only to localhost.