### PR TITLE
Implement custom CSS transform (port from PPTools)

### DIFF
--- a/ppcomp-action.php
+++ b/ppcomp-action.php
@@ -50,6 +50,10 @@ if(isset($_POST['txt-cleanup-type'])){
     $options[] = "--txt-cleanup-type " . escapeshellarg($_POST['txt-cleanup-type']);
 }
 
+if(isset($_POST['use-custom-transform-css']) && isset($_POST['css'])){
+    $options[] = "--css " . escapeshellarg($_POST['css']);
+}
+
 // ----- no errors. proceed ----------------------------------------
 
 log_tool_access("ppcomp", $upid);

--- a/ppcomp.php
+++ b/ppcomp.php
@@ -66,6 +66,16 @@ or views the results file.</p>
 
 <input type="checkbox" name="suppress-sidenote-tags" value="No" id="suppress-sidenote-tags">
 <label for="suppress-sidenote-tags">Suppress "[Sidenote:" marks</label><br>
+
+<input type="checkbox" name="use-custom-transform-css" value="No" id="use-custom-transform-css">
+<label for="use-custom-transform-css">Use custom transform CSS</label><br>
+<textarea id="css" name="css" rows="8" cols="60">
+/* Add brackets around footnote anchor */
+/*   .fnanchor:before { content: "["; }
+     .fnanchor:after { content: "]"; } */
+
+/* .tb {display: none;} */
+</textarea><br>
 <br>
 
 <div>If comparing with a file from the rounds</div>
@@ -113,5 +123,18 @@ program comp_pp.py by bibimbop at PGDP as part of his
 <a href='https://pptools.tangledhelix.com'>PPTOOLS</a> program.
 It is used as part of the PP Workbench with permission.
 </p>
+
+<script>
+function customTransformCssShowHide(e) {
+  if ($("#use-custom-transform-css").is(":checked")) {
+    $("#css").show();
+  } else {
+    $("#css").hide();
+  }
+}
+customTransformCssShowHide(false);
+$("#use-custom-transform-css").on("click", customTransformCssShowHide);
+</script>
+
 MENU;
 }


### PR DESCRIPTION
[PPTools](https://pptools.tangledhelix.com) has a ppcomp feature allowing the user to input their own CSS rules to transform in interesting ways. This is already supported by ppcomp.py (which is shared between PPWB and PPTools).

This commit allows the user to use custom CSS via PPWB.