### PR TITLE
Allow user to access `css-no-default` option in ppcomp

### DIFF
--- a/ppcomp.php
+++ b/ppcomp.php
@@ -67,6 +67,9 @@ or views the results file.</p>
 <input type="checkbox" name="suppress-sidenote-tags" value="No" id="suppress-sidenote-tags">
 <label for="suppress-sidenote-tags">Suppress "[Sidenote:" marks</label><br>
 
+<input type="checkbox" name="css-no-default" value="No" id="css-no-default">
+<label for="css-no-default">Do not use default transformation CSS</label><br>
+
 <input type="checkbox" name="use-custom-transform-css" value="No" id="use-custom-transform-css">
 <label for="use-custom-transform-css">Use custom transform CSS</label><br>
 <textarea id="css" name="css" rows="8" cols="60">


### PR DESCRIPTION
The last thing (I think) from PPTools that PPWB can't do is to disable the default CSS transform on the HTML file. It's already implemented in ppcomp; this PR just gives the user a checkbox that lets them use it.

It's fairly easy to test, just try with and without. Using a common HTML file such as produced by Guiguts, with the default CSS removed, you'll see page markers in the diff. `[Pg 1]` and so on.

