### PR TITLE
Remove tangledhelix URL

### DIFF
--- a/ppcomp.php
+++ b/ppcomp.php
@@ -122,8 +122,7 @@ or views the results file.</p>
 
 
 <p>Note: The ppcomp program program was originally written as the standalone
-program comp_pp.py by bibimbop at PGDP as part of his
-<a href='https://pptools.tangledhelix.com'>PPTOOLS</a> program.
+program comp_pp.py by bibimbop at PGDP as part of his PPTOOLS program.
 It is used as part of the PP Workbench with permission.
 </p>
 

--- a/techinfo-ppcomp.php
+++ b/techinfo-ppcomp.php
@@ -9,8 +9,6 @@ output_header("ppcomp", ["ppcomp.php" => "PPCOMP"]);
 <li>
 The ppcomp program program was originally written as the standalone program comp_pp.py
 by bibimbop at pgdp. It is used as part of the DP Workbench with permission.
-Users who want a compare tool with many more options might find
-the <a href='https://pptools.tangledhelix.com'>tangledhelix</a> site useful.
 </li>
 </ol>
 


### PR DESCRIPTION
The tangledhelix site is being decommissioned in the near future; features have been slowly merging into the PPWB suite instead. Removes link here so in future it won't become a dead link.