### PR TITLE
Increase max POST and upload size for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ RUN mkdir /venv \
     && /venv/bin/pip3 install \
         tinycss cssselect lxml html5lib pytest Pillow regex roman
 RUN pecl install zip \
-    && echo "extension=zip" >> $PHP_INI_DIR/php.ini-development \
-    && mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
+    && sed -e 's/\(post_max_size\s*=\s*\)[0-9]*M/\150M/' \
+           -e 's/\(upload_max_filesize\s*=\s*\)[0-9]*M/\150M/' \
+           $PHP_INI_DIR/php.ini-development > $PHP_INI_DIR/php.ini \
+    && echo "extension=zip" >> $PHP_INI_DIR/php.ini
 
 COPY docker-entrypoint.sh /
 RUN chmod 755 /docker-entrypoint.sh


### PR DESCRIPTION
A number of my projects used for testing were too big for PHP's default max POST size and upload size; increase these in the Docker container for testing purposes. (Won't affect the production site.)